### PR TITLE
FEAT: Reporting for package validation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <mvn.surefire.version>2.19.1</mvn.surefire.version>
     <mvn.release.version>2.5.3</mvn.release.version>
     <jacoco.version>0.8.7</jacoco.version>
-    <java.source.version>17</java.source.version>
-    <java.target.version>17</java.target.version>
+    <java.source.version>11</java.source.version>
+    <java.target.version>11</java.target.version>
     <junit.version>4.13.2</junit.version>
     <mvn.target.release>11</mvn.target.release>
     <picocli.version>4.7.0</picocli.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,8 +69,8 @@
     <mvn.surefire.version>2.19.1</mvn.surefire.version>
     <mvn.release.version>2.5.3</mvn.release.version>
     <jacoco.version>0.8.7</jacoco.version>
-    <java.source.version>11</java.source.version>
-    <java.target.version>11</java.target.version>
+    <java.source.version>17</java.source.version>
+    <java.target.version>17</java.target.version>
     <junit.version>4.13.2</junit.version>
     <mvn.target.release>11</mvn.target.release>
     <picocli.version>4.7.0</picocli.version>

--- a/src/main/java/org/openpreservation/messages/MessageLogImpl.java
+++ b/src/main/java/org/openpreservation/messages/MessageLogImpl.java
@@ -5,38 +5,46 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-public class MessageLogImpl implements MessageLog {
+class MessageLogImpl implements MessageLog {
     private final List<Message> messages = new ArrayList<>();
+    @Override
     public int size() {
         return this.messages.size();
     }
 
+    @Override
     public boolean isEmpty() {
         return this.messages.isEmpty();
     }
 
+    @Override
     public int add(Message message) {
         this.messages.add(message);
         return this.size();
     }
 
+    @Override
     public int add(Collection<? extends Message> messages) {
         this.messages.addAll(messages);
         return this.size();
     }
 
+    @Override
     public List<Message> getErrors() {
         return getMessages(Message.Severity.ERROR);
     }
 
+    @Override
     public List<Message> getWarnings() {
         return getMessages(Message.Severity.WARNING);
     }
 
+    @Override
     public List<Message> getInfos() {
         return getMessages(Message.Severity.INFO);
     }
 
+    @Override
     public List<Message> getMessages(Message.Severity severity) {
         List<Message> filteredList = new ArrayList<>();
         for (Message message : this.messages) {

--- a/src/main/java/org/openpreservation/messages/Messages.java
+++ b/src/main/java/org/openpreservation/messages/Messages.java
@@ -145,4 +145,8 @@ public enum Messages {
                 locale);
         return MessageFactoryImpl.getInstance(messageBundle);
     }
+
+    public static MessageLog messageLogInstance() {
+        return new MessageLogImpl();
+    }
 }

--- a/src/main/java/org/openpreservation/odf/ConsoleFormatter.java
+++ b/src/main/java/org/openpreservation/odf/ConsoleFormatter.java
@@ -1,5 +1,7 @@
 package org.openpreservation.odf;
 
+import java.nio.file.Path;
+
 import org.openpreservation.messages.Message;
 
 import picocli.CommandLine.Help.Ansi;
@@ -14,39 +16,53 @@ public enum ConsoleFormatter {
     public static final String COL_INFO = COL_GREEN;
     public static final String COL_WARN = COL_YELLOW;
 
-    public static void error(final String message) {
+    public static final void error(final String message) {
         colourise(message, COL_ERR);
     }
 
-    public static void info(final String message) {
+    public static final void info(final String message) {
         colourise(message, COL_INFO);
     }
 
-    public static void warn(final String message) {
+    public static final void warn(final String message) {
         colourise(message, COL_WARN);
     }
 
-    public static void colourise(final String message, final String colour) {
+    public static final void colourise(final String message, final String colour) {
         System.out.println(Ansi.AUTO.string(String.format("@|%s %s |@", colour, message)));
     }
 
-    public static void newline() {
+    public static final void newline() {
         System.out.println();
     }
 
-    public static void colourise(final Message message) {
-        if (message.isError() || message.isFatal()) {
-            colourise(message, COL_ERR);
-        } else if (message.isWarning()) {
-            colourise(message, COL_WARN);
-        } else {
-            colourise(message, COL_INFO);
-        }
+    public static final void colourise(final Message message) {
+        colourise(message, colourFromMessage(message));
     }
 
-    public static void colourise(final Message message, final String colour) {
+    public static final void colourise(final Path path, final Message message) {
+        colourise(path, message, colourFromMessage(message));
+    }
+
+    public static final void colourise(final Message message, final String colour) {
         final String formatted = String.format("%s: [%s] %s", message.getId(), message.getSeverity(),
                 message.getMessage());
         colourise(formatted, colour);
+    }
+
+    public static final void colourise(final Path path, final Message message, final String colour) {
+        final String formatted = String.format("%s: %s [%s] %s", path, message.getId(), message.getSeverity(),
+                message.getMessage());
+        colourise(formatted, colour);
+    }
+
+    private static final String colourFromMessage(final Message message) {
+        if (message.isError() || message.isFatal()) {
+            return COL_ERR;
+        } else if (message.isWarning()) {
+            return COL_WARN;
+        } else {
+            return COL_INFO;
+        }
     }
 }

--- a/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
+++ b/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
@@ -1,0 +1,105 @@
+package org.openpreservation.odf.validation;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.openpreservation.messages.Message;
+import org.openpreservation.messages.MessageLog;
+import org.openpreservation.messages.Messages;
+
+public class ValidationReport {
+    final Path path;
+    public final Map<Path, MessageLog> documentMessages;
+
+    public ValidationReport(final Path path) {
+        this(path, new HashMap<>());
+    }
+
+    public ValidationReport(final Path path, final Map<Path, MessageLog> documentMessages) {
+        super();
+        this.path = path;
+        this.documentMessages = documentMessages;
+    }
+
+    public boolean isValid() {
+        return documentMessages.values().stream().allMatch(m -> m.getErrors().isEmpty());        
+    }
+
+    public int add(final Path path, final Message message) {
+        this.documentMessages.putIfAbsent(path, Messages.messageLogInstance());
+        return this.documentMessages.get(path).add(message);
+    }
+
+    public int add(final Path path, final Collection<? extends Message> messages) {
+        this.documentMessages.putIfAbsent(path, Messages.messageLogInstance());
+        return this.documentMessages.get(path).add(messages);
+    }
+
+    public List<Message> getErrors() {
+        return documentMessages.values().stream().flatMap(m -> m.getErrors().stream()).collect(Collectors.toList());
+    }
+
+    public List<Message> getErrors(final Path path) {
+        return documentMessages.get(path).getErrors();
+    }
+
+    public List<Message> getWarnings() {
+        return documentMessages.values().stream().flatMap(m -> m.getWarnings().stream()).collect(Collectors.toList());
+    }
+
+    public List<Message> getWarnings(final Path path) {
+        return documentMessages.get(path).getWarnings();
+    }
+
+    public List<Message> getInfos() {
+        return documentMessages.values().stream().flatMap(m -> m.getInfos().stream()).collect(Collectors.toList());
+    }
+
+    public List<Message> getInfos(final Path path) {
+        return documentMessages.get(path).getInfos();
+    }
+
+    public List<Message> getMessages() {
+        return documentMessages.values().stream().flatMap(m -> m.getMessages().stream()).collect(Collectors.toList());
+    }
+
+    public List<Message> getMessages(final Path path) {
+        return documentMessages.get(path).getMessages();
+    }
+
+    public List<Message> getMessages(final Path path, final Message.Severity severity) {
+        return documentMessages.get(path).getMessages(severity);
+    }
+
+    public List<Message> getMessages(final Path path, final String id) {
+        return documentMessages.get(path).getMessages(id);
+    }
+
+    public boolean hasErrors() {
+        return documentMessages.values().stream().anyMatch(m -> m.hasErrors());
+    }
+
+    public boolean hasErrors(final Path path) {
+        return documentMessages.get(path).hasErrors();
+    }
+
+    public boolean hasWarnings() {
+        return documentMessages.values().stream().anyMatch(m -> m.hasWarnings());
+    }
+
+    public boolean hasWarnings(final Path path) {
+        return documentMessages.get(path).hasWarnings();
+    }
+
+    public boolean hasInfos() {
+        return documentMessages.values().stream().anyMatch(m -> m.hasInfos());
+    }
+
+    public boolean hasInfos(final Path path) {
+        return documentMessages.get(path).hasInfos();
+    }
+}

--- a/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -3,15 +3,17 @@ package org.openpreservation.odf.validation;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipException;
 import java.util.zip.ZipFile;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.openpreservation.messages.Message;
 import org.openpreservation.messages.MessageFactory;
-import org.openpreservation.messages.MessageLog;
-import org.openpreservation.messages.MessageLogImpl;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.xml.XmlChecker;
 import org.openpreservation.odf.xml.XmlParseResult;
@@ -21,108 +23,106 @@ import org.xml.sax.SAXNotSupportedException;
 public class Validator {
     private static final String MIME_TEMPLATE = "application/vnd.oasis.opendocument.spreadsheet-template";
     private static final String MIME_DOCUMENT = "application/vnd.oasis.opendocument.spreadsheet";
-    private static final String NAME_META_INF = "META-INF";
+    private static final String NAME_META_INF = "META-INF/";
     private static final String NAME_MANIFEST = "manifest.xml";
-    private static final String PATH_MANIFEST = NAME_META_INF + "/" + NAME_MANIFEST;
+    private static final String PATH_MANIFEST = NAME_META_INF + NAME_MANIFEST;
     private static final String NAME_CONTENT = "content.xml";
     private static final String TAG_DOC = "office:document";
     private static final String TAG_MANIFEST = "manifest:manifest";
     private static final MessageFactory FACTORY = Messages.getInstance();
 
-    public final MessageLog messages = new MessageLogImpl();
-
     public Validator() {
         super();
     }
 
-    public void validate(final Path toValidate)
+    public ValidationReport validate(final Path toValidate)
             throws SAXNotRecognizedException, SAXNotSupportedException, ParserConfigurationException, IOException {
-        if (isPackage(toValidate)) {
-            validatePackage(toValidate);
+        final ValidationReport report = new ValidationReport(toValidate);
+        if (isPackage(toValidate, report)) {
+            validatePackage(toValidate, report);
         } else {
             XmlChecker checker = new XmlChecker();
             XmlParseResult result = checker.parse(toValidate);
             if (result.isWellFormed) {
                 if (result.isRootName(TAG_DOC)) {
-                    this.messages.add(FACTORY.getInfo("PKG-3", result.version));
+                    report.add(toValidate, FACTORY.getInfo("PKG-3", result.version));
                     if (MIMETYPES.isDocument(result.mimeType)) {
-                        this.messages.add(FACTORY.getInfo("PKG-4", "Document", result.mimeType));
+                        report.add(toValidate, FACTORY.getInfo("PKG-4", "Document", result.mimeType));
                     } else if (MIMETYPES.isTemplate(result.mimeType)) {
-                        this.messages.add(FACTORY.getInfo("PKG-4", "Template", result.mimeType));
+                        report.add(toValidate, FACTORY.getInfo("PKG-4", "Template", result.mimeType));
                     } else {
-                        this.messages.add(FACTORY.getError("PKG-5", result.mimeType));
+                        report.add(toValidate, FACTORY.getError("PKG-5", result.mimeType));
                     }
                 }
                 result = checker.validate(toValidate);
-                this.messages.add(result.messages);
+                report.add(toValidate, result.messages);
             } else {
-                this.messages.add(result.messages);
-                this.messages.add(FACTORY.getError("PKG-7", toValidate));
+                report.add(toValidate, result.messages);
+                report.add(toValidate, FACTORY.getError("PKG-7", toValidate));
             }
         }
+        return report;
     }
 
-    public boolean isFile(Path toCheck) {
+    public static final boolean isFile(final Path toCheck) {
         // Check that the supplied path is an existing, regular file
-        if ((toCheck == null || !Files.exists(toCheck) || !Files.isRegularFile(toCheck))) {
-            this.messages.add(FACTORY.getFatal("SYS-1", toCheck));
-            return false;
-        }
-        return true;
+        return (toCheck != null || Files.exists(toCheck) || Files.isRegularFile(toCheck));
     }
 
-    private boolean isPackage(Path toCheck) {
+    private static final boolean isPackage(final Path toCheck, final ValidationReport report) {
+        final List<Message> messages = new ArrayList<>();
         try (ZipFile zipFile = new ZipFile(toCheck.toFile())) {
             return true;
         } catch (ZipException e) {
-            this.messages.add(FACTORY.getInfo("ZIP-1", toCheck));
+            messages.add(FACTORY.getInfo("ZIP-1", toCheck));
         } catch (IOException e) {
-            this.messages.add(FACTORY.getFatal("SYS-2", toCheck, e.getMessage()));
+            messages.add(FACTORY.getFatal("SYS-2", toCheck, e.getMessage()));
         }
+        report.add(toCheck, messages);
         return false;
     }
 
-    private boolean validatePackage(Path toValidate) {
+    private boolean validatePackage(final Path toValidate, final ValidationReport report) {
         boolean isValid = true;
         boolean manifestFound = false;
         try (ZipFile zipFile = new ZipFile(toValidate.toFile())) {
             for (ZipEntry entry : zipFile.stream().toArray(ZipEntry[]::new)) {
                 if ((entry.getMethod() != ZipEntry.STORED) && (entry.getMethod() != ZipEntry.DEFLATED)) {
-                    this.messages.add(FACTORY.getError("ZIP-2", entry.getName()));
+                    report.add(toValidate, FACTORY.getError("ZIP-2", entry.getName()));
                     isValid = false;
                 }
                 if (entry.getName().startsWith(NAME_META_INF)) {
                     if (entry.isDirectory() && !NAME_META_INF.equals(entry.getName())) {
-                        this.messages.add(FACTORY.getError("PKG-1", entry.getName()));
+                        report.add(toValidate, FACTORY.getError("PKG-1", entry.getName()));
                     } else if (entry.getName().equals(PATH_MANIFEST)) {
                         manifestFound = true;
                     }
                 }
             }
             if (!manifestFound) {
-                this.messages.add(FACTORY.getError("PKG-2"));
+                report.add(toValidate, FACTORY.getError("PKG-2"));
                 isValid = false;
             }
         } catch (IOException e) {
-            this.messages.add(FACTORY.getError("ZIP-3", toValidate.toString(), e.getMessage()));
+            report.add(toValidate, FACTORY.getError("ZIP-3", toValidate.toString(), e.getMessage()));
             isValid = false;
         }
         return isValid;
     }
 
-    private boolean validateMetInfEntry(final ZipFile packageZip, final ZipEntry metaInfEntry) throws IOException {
+    private boolean validateMetaInfEntry(final ZipFile odfPackage, final ZipEntry metaInfEntry, final ValidationReport report) throws IOException {
         boolean isValid = true;
         if (metaInfEntry.getName().equals(PATH_MANIFEST)) {
             try {
                 XmlChecker checker = new XmlChecker();
-                XmlParseResult result = checker.parse(packageZip.getInputStream(metaInfEntry),
+                XmlParseResult result = checker.parse(odfPackage.getInputStream(metaInfEntry),
                         metaInfEntry.getName());
                 if ((result.isWellFormed) && (!result.isRootName(TAG_MANIFEST))) {
-                    this.messages.add(FACTORY.getError("XML-2", metaInfEntry.getName()));
+                    report.add(Paths.get(odfPackage.getName()), FACTORY.getError("XML-2", metaInfEntry.getName()));
                     isValid = false;
                 }
             } catch (ParserConfigurationException | SAXNotRecognizedException | SAXNotSupportedException e) {
-                this.messages.add(FACTORY.getError("SYS-4", PATH_MANIFEST, e.getMessage()));
+                report.add(Paths.get(odfPackage.getName()), FACTORY.getError("SYS-4", PATH_MANIFEST, e.getMessage()));
             }
         } else if (metaInfEntry.getName().contains("signatures")) {
             // legal so parse as a digital signature

--- a/src/main/resources/org/openpreservation/odf/messages/Messages.properties
+++ b/src/main/resources/org/openpreservation/odf/messages/Messages.properties
@@ -1,5 +1,6 @@
 APP-1 = Validating %s.
 APP-2 = No messages.
+APP-3 = Validation report for %s.
 PKG-1 = Subdirectory %s not allowed in the META-INF folder.
 PKG-2 = No manifest.xml found in package META-INF
 PKG-3 = Open Document Format version %s detected.


### PR DESCRIPTION
- added prototype `ValidationReport` class to handle reporting of package validation errors;
- messages now minted on a per-path basis to allow accurate reporting of package errors;
- refactored other validation classes to use `ValidationReport` and `Messages`;
- made `MessageLogImpl` package protected and added factory method to `Messages`; and
- added `final` modifiers where appropriate.