### PR TITLE
REFACT: Package validation

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/fmt/Formats.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/fmt/Formats.java
@@ -6,18 +6,18 @@ import java.util.Set;
 import org.openpreservation.utils.Checks;
 
 public enum Formats {
-    ZIP("application/zip", EnumSet.of(Signatures.ZIP, Signatures.ZIP_EMPTY, Signatures.ZIP_SPANNED)),
-    XML("text/xml", EnumSet.of(Signatures.XML_UTF_8, Signatures.XML_UTF_16_LE, Signatures.XML_UTF_16_BE,
+    ZIP(MimeTypes.ZIP, EnumSet.of(Signatures.ZIP, Signatures.ZIP_EMPTY, Signatures.ZIP_SPANNED)),
+    XML(MimeTypes.XML, EnumSet.of(Signatures.XML_UTF_8, Signatures.XML_UTF_16_LE, Signatures.XML_UTF_16_BE,
             Signatures.XML_UTF_32_LE, Signatures.XML_UTF_32_BE)),
-    ODS("application/vnd.oasis.opendocument.spreadsheet", EnumSet.of(Signatures.ODS)),
-    OTS("application/vnd.oasis.opendocument.spreadsheet-template", EnumSet.of(Signatures.ODT)),
-    UNKNOWN("application/octet-stream", EnumSet.of(Signatures.NOMATCH));
+    ODS(MimeTypes.ODS, EnumSet.of(Signatures.ODS)),
+    OTS(MimeTypes.OTS, EnumSet.of(Signatures.ODT)),
+    UNKNOWN(MimeTypes.UNKNOWN, EnumSet.of(Signatures.NOMATCH));
 
-    public final String mime;
+    public final MimeTypes mime;
     public final String extension;
     final Set<Signatures> signatures;
 
-    private Formats(final String mime, final Set<Signatures> signatures) {
+    private Formats(final MimeTypes mime, final Set<Signatures> signatures) {
         this.mime = mime;
         this.extension = this.name().replace("UNKNOWN", "").toLowerCase();
         this.signatures = EnumSet.copyOf(signatures);
@@ -55,8 +55,9 @@ public enum Formats {
 
     public static Formats fromMime(final String mime) {
         Checks.notNull(mime, "String", "mime");
+        MimeTypes mimeType = MimeTypes.fromMime(mime);
         for (Formats f : Formats.values()) {
-            if (f.mime.equals(mime.toLowerCase())) {
+            if (f.mime == mimeType) {
                 return f;
             }
         }

--- a/odf-core/src/main/java/org/openpreservation/odf/fmt/MimeTypes.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/fmt/MimeTypes.java
@@ -1,0 +1,76 @@
+package org.openpreservation.odf.fmt;
+
+import java.nio.charset.StandardCharsets;
+
+import org.openpreservation.utils.Checks;
+
+public enum MimeTypes {
+    ZIP("application/zip", "zip"),
+    XML("text/xml", "xml"),
+    ODS("application/vnd.oasis.opendocument.spreadsheet", "ods"),
+    OTS("application/vnd.oasis.opendocument.spreadsheet-template", "ots"),
+    UNKNOWN("application/octet-stream", "bin");
+
+    private final static String STRING = "String";
+
+    /**
+     * The String MIME type identifier
+     */
+    public final String mime;
+    /**
+     * The String extension associated with the MIME type
+     */
+    public final String extension;
+
+    private MimeTypes(final String mime, final String extension) {
+        this.mime = mime;
+        this.extension = extension;
+    }
+
+    /**
+     * Get the MIME type as an ASCII encoded byte array.
+     * 
+     * @return the ASCII encoded MIME type id as a byte array
+     */
+    public byte[] getBytes() {
+        return this.mime.getBytes(StandardCharsets.US_ASCII);
+    }
+
+    /**
+     * Get the MimeType associated with the given extension.
+     * 
+     * @param ext the String extension to match the MimeType for
+     * 
+     * @return The MimeType associated with the given extension, or UNKNOWN if not
+     *         matched
+     */
+    public static MimeTypes fromExtension(final String ext) {
+        Checks.notNull(ext, STRING, "ext");
+        for (MimeTypes m : MimeTypes.values()) {
+            if (m.extension.equals(ext.toLowerCase())) {
+                return m;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public static MimeTypes fromMime(final String mime) {
+        Checks.notNull(mime, STRING, "mime");
+        for (MimeTypes m : MimeTypes.values()) {
+            if (m.mime.equals(mime.toLowerCase())) {
+                return m;
+            }
+        }
+        return UNKNOWN;
+    }
+
+    public static boolean isTemplate(final String mime) {
+        Checks.notNull(mime, STRING, "mime");
+        return mime.toLowerCase().equals(OTS.mime);
+    }
+
+    public static boolean isDocument(final String mime) {
+        Checks.notNull(mime, STRING, "mime");
+        return mime.toLowerCase().equals(ODS.mime);
+    }
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/fmt/ZipHandler.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/fmt/ZipHandler.java
@@ -1,5 +1,0 @@
-package org.openpreservation.odf.fmt;
-
-public class ZipHandler {
-    
-}

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackage.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackage.java
@@ -1,0 +1,16 @@
+package org.openpreservation.odf.pkg;
+
+import java.io.IOException;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.openpreservation.odf.validation.ValidationReport;
+import org.xml.sax.SAXException;
+
+public interface OdfPackage {
+    public String getMimeEntry();
+
+    public boolean hasMimeEntry();
+
+    public ValidationReport validate() throws IOException, ParserConfigurationException, SAXException;
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -1,0 +1,157 @@
+package org.openpreservation.odf.pkg;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.openpreservation.messages.MessageFactory;
+import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.validation.ValidationReport;
+import org.openpreservation.odf.xml.XmlChecker;
+import org.openpreservation.odf.xml.XmlParseResult;
+import org.openpreservation.utils.Checks;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXNotRecognizedException;
+import org.xml.sax.SAXNotSupportedException;
+
+public class OdfPackageImpl implements OdfPackage {
+    static final String MIMETYPE = "mimetype";
+    private static final String NAME_META_INF = "META-INF/";
+    private static final String NAME_MANIFEST = "manifest.xml";
+    private static final String PATH_MANIFEST = NAME_META_INF + NAME_MANIFEST;
+    private static final String NAME_CONTENT = "content.xml";
+    private static final String TAG_MANIFEST = "manifest:manifest";
+    private static final MessageFactory FACTORY = Messages.getInstance();
+
+    private boolean mimeEntryFound = false;
+    private boolean manifestFound = false;
+    private String mimeEntry = "";
+    private final Path path;
+    private final ValidationReport report;
+
+    public OdfPackageImpl(final Path toValidate) {
+        super();
+        this.path = toValidate;
+        report = new ValidationReport(path);
+    }
+
+    @Override
+    public String getMimeEntry() {
+        return this.mimeEntry;
+    }
+
+    @Override
+    public boolean hasMimeEntry() {
+        return this.mimeEntryFound;
+    }
+
+    @Override
+    public ValidationReport validate()
+            throws IOException, ParserConfigurationException, SAXException {
+        try (InputStream is = new FileInputStream(this.path.toFile())) {
+            validate(is);
+        }
+        if (!mimeEntryFound) {
+            report.add(path, FACTORY.getWarning("PKG-2"));
+        }
+        if (!manifestFound) {
+            report.add(path, FACTORY.getError("PKG-4"));
+        }
+        return report;
+    }
+
+    public void validate(final InputStream toValidate) throws IOException, ParserConfigurationException, SAXException {
+        int entryCount = 0;
+        // Throw a Zip Stream around the passed input stream
+        try (BufferedInputStream bis = new BufferedInputStream(toValidate);
+                ZipInputStream zis = new ZipInputStream(bis)) {
+            ZipEntry entry;
+            // Process the zip entries in order
+            while ((entry = zis.getNextEntry()) != null) {
+                entryCount++;
+                if ((entry.getMethod() != ZipEntry.STORED) && (entry.getMethod() != ZipEntry.DEFLATED)) {
+                    // Entries SHALL be uncompressesed (Stored) or use deflate compression
+                    report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-1", entry.getName()));
+                }
+                if (entry.getName().equals(MIMETYPE) && !entry.isDirectory()) {
+                    // Check the mimetype entry when it's found
+                    this.validateMimeEntry(zis, entry, entryCount == 1);
+                }
+                if (entry.getName().startsWith(NAME_META_INF)) {
+                    if (entry.isDirectory() && !NAME_META_INF.equals(entry.getName())) {
+                        report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-3", entry.getName()));
+                    } else if (entry.getName().equals(PATH_MANIFEST)) {
+                        this.validateMetaInfEntry(zis, entry);
+                    }
+                }
+            }
+        }
+    }
+
+    private void validateMimeEntry(final InputStream is, final ZipEntry mimeEntry, final boolean isFirst)
+            throws IOException {
+        mimeEntryFound = true;
+        try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            Checks.copyStream(is, bos);
+            this.mimeEntry = bos.toString(StandardCharsets.US_ASCII);
+        }
+        if (!isFirst) {
+            report.add(Paths.get(mimeEntry.getName()), FACTORY.getError("PKG-7"));
+        }
+        if (mimeEntry.getMethod() != ZipEntry.STORED) {
+            report.add(Paths.get(mimeEntry.getName()), FACTORY.getError("PKG-6"));
+        }
+
+        if (mimeEntry.getExtra() != null) {
+            report.add(Paths.get(mimeEntry.getName()), FACTORY.getError("PKG-8"));
+        }
+    }
+
+    private int copyEntryToFile(final InputStream source, final Path dest) throws IOException {
+        return this.copyEntryToFile(source, dest.toFile());
+    }
+
+    private int copyEntryToFile(final InputStream source, final File dest) throws IOException {
+        try (FileOutputStream fos = new FileOutputStream(dest);
+                BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            return Checks.copyStream(source, bos);
+        }
+    }
+
+    private void validateMetaInfEntry(final InputStream is, final ZipEntry metaInfEntry)
+            throws IOException, ParserConfigurationException, SAXException {
+        if (metaInfEntry.getName().equals(PATH_MANIFEST)) {
+            this.manifestFound = true;
+            this.validateManifest(is, metaInfEntry);
+        } else if (metaInfEntry.getName().contains("signatures")) {
+            // legal so parse as a digital signature
+        }
+    }
+
+    private void validateManifest(final InputStream is, final ZipEntry metaInfEntry)
+            throws ParserConfigurationException, IOException, SAXException {
+        XmlChecker checker = new XmlChecker();
+        Path tempFile = Files.createTempFile(null, null);
+        this.copyEntryToFile(is, tempFile);
+        try (InputStream tempIs = new FileInputStream(tempFile.toFile())) {
+            XmlParseResult result = checker.parse(tempIs, Paths.get(metaInfEntry.getName()));
+            if ((result.isWellFormed) && (!result.isRootName(TAG_MANIFEST))) {
+                report.add(Paths.get(metaInfEntry.getName()), FACTORY.getError("XML-2", metaInfEntry.getName()));
+            }
+        }
+    }
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
@@ -1,0 +1,22 @@
+package org.openpreservation.odf.pkg;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+public class OdfPackages {
+    public static final String MIMETYPE = OdfPackageImpl.MIMETYPE;
+
+    public static final boolean isPackage(final Path toCheck) throws IOException {
+        try (ZipFile zipFile = new ZipFile(toCheck.toFile())) {
+            return true;
+        } catch (ZipException e) {
+            /**
+             * No need to report this as an error as it simply means that the file is not a
+             * ZIP
+             */
+        }
+        return false;
+    }
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -1,36 +1,24 @@
 package org.openpreservation.odf.validation;
 
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Scanner;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
-import java.util.zip.ZipInputStream;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.openpreservation.messages.MessageFactory;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.fmt.MimeTypes;
+import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.OdfPackageImpl;
+import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.xml.XmlChecker;
 import org.openpreservation.odf.xml.XmlParseResult;
 import org.xml.sax.SAXException;
 
 public class Validator {
-    private static final String MIME_TEMPLATE = "application/vnd.oasis.opendocument.spreadsheet-template";
-    private static final String MIME_DOCUMENT = "application/vnd.oasis.opendocument.spreadsheet";
-    private static final String NAME_META_INF = "META-INF/";
-    private static final String NAME_MANIFEST = "manifest.xml";
-    private static final String PATH_MANIFEST = NAME_META_INF + NAME_MANIFEST;
-    private static final String NAME_CONTENT = "content.xml";
     private static final String TAG_DOC = "office:document";
-    private static final String TAG_MANIFEST = "manifest:manifest";
     private static final MessageFactory FACTORY = Messages.getInstance();
 
     public Validator() {
@@ -45,28 +33,28 @@ public class Validator {
         if (!isFile(toValidate)) {
             throw new FileNotFoundException("Path parameter is not a file: " + toValidate);
         }
-        final ValidationReport report = new ValidationReport(toValidate);
-        if (isPackage(toValidate)) {
-            validatePackage(toValidate, report);
-        } else {
-            XmlChecker checker = new XmlChecker();
-            XmlParseResult result = checker.parse(toValidate);
-            if (result.isWellFormed) {
-                if (result.isRootName(TAG_DOC)) {
-                    report.add(toValidate, FACTORY.getInfo("DOC-2", result.version));
-                    if (MIMETYPES.isDocument(result.mimeType)) {
-                        report.add(toValidate, FACTORY.getInfo("DOC-3", "Document", result.mimeType));
-                    } else if (MIMETYPES.isTemplate(result.mimeType)) {
-                        report.add(toValidate, FACTORY.getInfo("DOC-3", "Template", result.mimeType));
-                    } else {
-                        report.add(toValidate, FACTORY.getError("DOC-4", result.mimeType));
-                    }
+        if (OdfPackages.isPackage(toValidate)) {
+            OdfPackage pkg = new OdfPackageImpl(toValidate);
+            return pkg.validate();
+        }
+        ValidationReport report = new ValidationReport(toValidate);
+        XmlChecker checker = new XmlChecker();
+        XmlParseResult result = checker.parse(toValidate);
+        if (result.isWellFormed) {
+            if (result.isRootName(TAG_DOC)) {
+                report.add(toValidate, FACTORY.getInfo("DOC-2", result.version));
+                if (MimeTypes.isDocument(result.mimeType)) {
+                    report.add(toValidate, FACTORY.getInfo("DOC-3", "Document", result.mimeType));
+                } else if (MimeTypes.isTemplate(result.mimeType)) {
+                    report.add(toValidate, FACTORY.getInfo("DOC-3", "Template", result.mimeType));
+                } else {
+                    report.add(toValidate, FACTORY.getError("DOC-4", result.mimeType));
                 }
-                result = checker.validate(toValidate);
-                report.add(toValidate, result.messages);
-            } else {
-                report.add(toValidate, result.messages);
             }
+            result = checker.validate(toValidate);
+            report.add(toValidate, result.messages);
+        } else {
+            report.add(toValidate, result.messages);
         }
         return report;
     }
@@ -74,109 +62,5 @@ public class Validator {
     private static final boolean isFile(final Path toCheck) {
         // Check that the supplied path is an existing, regular file
         return (toCheck != null && Files.exists(toCheck) && Files.isRegularFile(toCheck));
-    }
-
-    private static final boolean isPackage(final Path toCheck) throws IOException {
-        try (ZipFile zipFile = new ZipFile(toCheck.toFile())) {
-            return true;
-        } catch (ZipException e) {
-            /**
-             * No need to report this as an error as it simply means that the file is not a
-             * ZIP
-             */
-        }
-        return false;
-    }
-
-    private boolean validatePackage(final Path toValidate, final ValidationReport report)
-            throws IOException {
-        boolean isValid = true;
-        boolean manifestFound = false;
-        boolean mimetypeFound = false;
-
-        try (FileInputStream fis = new FileInputStream(toValidate.toFile()); ZipInputStream zis = new ZipInputStream(fis)) {
-            ZipEntry entry = zis.getNextEntry();
-            if (entry.getName().equals("mimetype") && !entry.isDirectory()) {
-                mimetypeFound = true;
-
-                try (Scanner s = new Scanner(zis).useDelimiter("\\A")) {
-                    if (!StandardCharsets.US_ASCII.newEncoder().canEncode(s.hasNext() ? s.next() : "")) {
-                        report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-5"));
-                        isValid = false;
-                    }
-                }
-
-                if (entry.getMethod() != ZipEntry.STORED) {
-                    report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-6"));
-                }
-
-                if (entry.getExtra() != null) {
-                    report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-8"));
-                }
-            }
-        }
-        try (ZipFile zipFile = new ZipFile(toValidate.toFile())) {
-            for (ZipEntry entry : zipFile.stream().toArray(ZipEntry[]::new)) {
-                if ((entry.getMethod() != ZipEntry.STORED) && (entry.getMethod() != ZipEntry.DEFLATED)) {
-                    report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-1", entry.getName()));
-                    isValid = false;
-                }
-                if (entry.getName().equals("mimetype") && !entry.isDirectory() && !mimetypeFound) {
-                    mimetypeFound = true;
-                    report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-7"));
-                    isValid = false;
-                } else if (entry.getName().startsWith(NAME_META_INF)) {
-                    if (entry.isDirectory() && !NAME_META_INF.equals(entry.getName())) {
-                        report.add(Paths.get(entry.getName()), FACTORY.getError("PKG-3", entry.getName()));
-                    } else if (entry.getName().equals(PATH_MANIFEST)) {
-                        manifestFound = true;
-                    }
-                }
-            }
-            if (!mimetypeFound) {
-                report.add(toValidate, FACTORY.getWarning("PKG-2"));
-            }
-            if (!manifestFound) {
-                report.add(toValidate, FACTORY.getError("PKG-4"));
-                isValid = false;
-            }
-        }
-        return isValid;
-    }
-
-    private boolean validateMetaInfEntry(final ZipFile odfPackage, final ZipEntry metaInfEntry,
-            final ValidationReport report) throws IOException, ParserConfigurationException, SAXException {
-        boolean isValid = true;
-        if (metaInfEntry.getName().equals(PATH_MANIFEST)) {
-            XmlChecker checker = new XmlChecker();
-            XmlParseResult result = checker.parse(odfPackage.getInputStream(metaInfEntry),
-                    Paths.get(metaInfEntry.getName()));
-            if ((result.isWellFormed) && (!result.isRootName(TAG_MANIFEST))) {
-                report.add(Paths.get(odfPackage.getName()), FACTORY.getError("XML-2", metaInfEntry.getName()));
-                isValid = false;
-            }
-        } else if (metaInfEntry.getName().contains("signatures")) {
-            // legal so parse as a digital signature
-        }
-        return isValid;
-    }
-
-    public enum MIMETYPES {
-        TEMPLATE(MIME_TEMPLATE),
-        DOCUMENT(MIME_DOCUMENT);
-
-        public final String value;
-
-        private MIMETYPES(final String value) {
-            this.value = value;
-        }
-
-        public static boolean isTemplate(final String mime) {
-            return mime.toLowerCase().equals(TEMPLATE.value);
-        }
-
-        public static boolean isDocument(final String mime) {
-            return mime.toLowerCase().equals(DOCUMENT.value);
-        }
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/utils/Checks.java
+++ b/odf-core/src/main/java/org/openpreservation/utils/Checks.java
@@ -1,7 +1,12 @@
 package org.openpreservation.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 public class Checks {
     private static final String NOT_NULL = "%s parameter: %s must not be null.";
+    private static final int BUFFER_SIZE = 4096;
 
     private Checks() {
         throw new AssertionError("Should not be instantiated.");
@@ -15,6 +20,7 @@ public class Checks {
 
     /**
      * see https://stackoverflow.com/a/140861
+     * 
      * @param s
      * @return
      */
@@ -23,7 +29,18 @@ public class Checks {
         byte[] data = new byte[len / 2];
         for (int i = 0; i < len; i += 2) {
             data[i / 2] = (byte) ((Character.digit(s.charAt(i), 16) << 4)
-                                 + Character.digit(s.charAt(i+1), 16));
+                    + Character.digit(s.charAt(i + 1), 16));
         }
         return data;
-    }}
+    }
+
+    public static int copyStream(final InputStream source, final OutputStream dest) throws IOException {
+        int len = 0;
+        byte[] buffer = new byte[BUFFER_SIZE];
+        while ((len = source.read(buffer)) > 0) {
+            dest.write(buffer, 0, len);
+        }
+        return len;
+    }
+
+}

--- a/odf-core/src/test/java/org/openpreservation/odf/fmt/FormatsTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/fmt/FormatsTest.java
@@ -72,7 +72,7 @@ public class FormatsTest {
 
     @Test
     public void testFromMimeOts() {
-        assertEquals(String.format("%s IS the MIME identifier for %s", MIME_ODS, Formats.OTS),
+        assertEquals(String.format("%s IS the MIME identifier for %s", MIME_OTS, Formats.OTS),
                 Formats.OTS,
                 Formats.fromMime(MIME_OTS));
     }
@@ -125,7 +125,7 @@ public class FormatsTest {
 
     @Test
     public void testFromExtOts() {
-        assertEquals(String.format("%s IS the MIME identifier for %s", EXT_ODS, Formats.OTS),
+        assertEquals(String.format("%s IS the MIME identifier for %s", EXT_OTS, Formats.OTS),
                 Formats.OTS,
                 Formats.fromExtension(EXT_OTS));
     }


### PR DESCRIPTION
- moving towards production ready package structure;
- package validation is now performed by `OdfPackage` interface but still needs a model and validation class;
- using improved `odf-core` enum types for MIME and extension String constants;
- much tidier loop handling for package entry processing;
- factored out common copy methods for streams;
- `OdfPackageCreator` no longer generates missing `mimetype` entry; and
- grouped/removed repeated string constants.