### PR TITLE
TEST: Document type identification

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/format/xml/XmlParser.java
+++ b/odf-core/src/main/java/org/openpreservation/format/xml/XmlParser.java
@@ -6,6 +6,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
@@ -48,6 +49,7 @@ public class XmlParser {
 
     public ParseResult parse(final InputStream toTest)
             throws IOException {
+        Objects.requireNonNull(toTest, "Parameter toTest can not be null.");
         final List<Message> messages = new ArrayList<>();
         ParsingHandler handler = new ParsingHandler();
         MessageHandler messageHandler = new MessageHandler();
@@ -68,6 +70,7 @@ public class XmlParser {
 
     public ParseResult parse(Path toTest)
             throws IOException {
+        Objects.requireNonNull(toTest, "Parameter toTest can not be null.");
         return parse(Files.newInputStream(toTest));
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/fmt/Formats.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/fmt/Formats.java
@@ -101,6 +101,17 @@ public enum Formats {
         return ODF_DOCUMENTS.contains(this);
     }
 
+    public int getSignatureCount() {
+        return signatures.size();
+    }
+
+    public int getMaxSignatureLength() {
+        int max = 0;
+        for (final Signatures s : signatures) {
+            max = Math.max(max, s.getLength());
+        }
+        return max;
+    }
     /**
      * Get the MIME type as an ASCII encoded byte array.
      *

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
@@ -61,7 +61,7 @@ public final class OdfPackages {
      * @throws IOException if there's an issue reading the file
      */
     public static final boolean isZip(final Path toCheck) throws IOException {
-        return FormatSniffer.sniff(toCheck, 10) == Formats.ZIP;
+        return FormatSniffer.sniff(toCheck, Formats.ZIP.getMaxSignatureLength()) == Formats.ZIP;
     }
 
     /**

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
@@ -60,7 +60,7 @@ final class ValidatingParserImpl implements ValidatingParser {
     public ValidationReport validatePackage(final OdfPackage toValidate) {
         Objects.requireNonNull(toValidate, String.format(Checks.NOT_NULL, TO_VALIDATE, "OdfPackage"));
         this.results.clear();
-        final ValidationReport report = new ValidationReport(toValidate.getName());
+        final ValidationReport report = ValidationReport.of(toValidate.getName());
         if (!toValidate.isWellFormedZip()) {
             report.add(toValidate.getName(), FACTORY.getError("PKG-9"));
             return report;
@@ -84,7 +84,7 @@ final class ValidatingParserImpl implements ValidatingParser {
     }
 
     private ValidationReport validate(final OdfPackage odfPackage) {
-        final ValidationReport report = new ValidationReport(odfPackage.getName());
+        final ValidationReport report = ValidationReport.of(odfPackage.getName());
         report.add(OdfFormats.MIMETYPE, checkMimeEntry(odfPackage));
         if (!odfPackage.hasManifest()) {
             report.add(OdfPackages.PATH_MANIFEST, FACTORY.getError("PKG-4"));

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
@@ -14,14 +14,22 @@ public class ValidationReport {
     final String name;
     public final Map<String, MessageLog> documentMessages;
 
-    public ValidationReport(final String name) {
+    private ValidationReport(final String name) {
         this(name, new HashMap<>());
     }
 
-    public ValidationReport(final String name, final Map<String, MessageLog> documentMessages) {
+    private ValidationReport(final String name, final Map<String, MessageLog> documentMessages) {
         super();
         this.name = name;
         this.documentMessages = documentMessages;
+    }
+
+    static final ValidationReport of(final String name) {
+        return new ValidationReport(name);
+    }
+
+    static final ValidationReport of(final String name, final Map<String, MessageLog> documentMessages) {
+        return new ValidationReport(name, documentMessages);
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/xml/OdfXmlDocuments.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/xml/OdfXmlDocuments.java
@@ -2,12 +2,15 @@ package org.openpreservation.odf.xml;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.openpreservation.format.xml.ParseResult;
+import org.openpreservation.odf.fmt.FormatSniffer;
+import org.openpreservation.odf.fmt.Formats;
 import org.openpreservation.odf.xml.Metadata.UserDefinedField;
 import org.xml.sax.SAXException;
 
@@ -80,4 +83,14 @@ public final class OdfXmlDocuments {
         return MetadataImpl.from(metaStream);
     }
 
+    /**
+     * Determines whether the supplied path is an XML document or not.
+     *
+     * @param toCheck a Java Path for the file to check
+     * @return true if the supplied path is an XML document, false otherwise.
+     * @throws IOException when there is an error reading the file.
+     */
+    public static final boolean isXml(final Path toCheck) throws IOException {
+        return FormatSniffer.sniff(toCheck, Formats.XML.getMaxSignatureLength()) == Formats.XML;
+    }
 }

--- a/odf-core/src/main/java/org/openpreservation/utils/Checks.java
+++ b/odf-core/src/main/java/org/openpreservation/utils/Checks.java
@@ -2,7 +2,7 @@ package org.openpreservation.utils;
 
 public class Checks {
     public static final String NOT_NULL = "%s parameter: %s must not be null.";
-    public static final String NOT_EMPTY = "sTRING parameter: %s must not be empty.";
+    public static final String NOT_EMPTY = "String parameter: %s must not be empty.";
     public static final String GREATER_THAN_OR_EQUAL_TO = "Parameter: %s must be greater than or equal to %s.";
 
     private Checks() {

--- a/odf-core/src/test/java/org/openpreservation/format/xml/XmlParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/format/xml/XmlParserTest.java
@@ -4,9 +4,14 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -15,6 +20,21 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.xml.sax.SAXException;
 
 public class XmlParserTest {
+    public void testParseNull() throws ParserConfigurationException, SAXException {
+        XmlParser xmlChecker = new XmlParser();
+        InputStream nullStream = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    xmlChecker.parse(nullStream);
+                });
+        Path nullPath = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    xmlChecker.parse(nullPath);
+                });
+    }
 
     @Test
     public void testParseWF() throws ParserConfigurationException, SAXException, IOException {
@@ -103,9 +123,9 @@ public class XmlParserTest {
     }
 
     @Test
-    public void testParseEmpty() throws ParserConfigurationException, SAXException, IOException {
+    public void testParseEmptyByPath() throws ParserConfigurationException, SAXException, IOException, URISyntaxException {
         XmlParser xmlChecker = new XmlParser();
-        ParseResult result = xmlChecker.parse(TestFiles.EMPTY.openStream());
+        ParseResult result = xmlChecker.parse(new File(TestFiles.EMPTY.toURI()).toPath());
         assertNotNull("Parse result is not null", result);
         assertFalse("Parse result should NOT be well formed", result.isWellFormed());
         assertTrue("Parse result should NOT have root name", result.getRootName().isBlank());


### PR DESCRIPTION
- Validator now does a better job of identifying the document type submitted;
- convenience methods to get the number and maximum length of Format signatures;
- better instantiation methods for ValidationReport;
- null checks for `XmlParser` method paramters and matching tests;
- tidied some exception handling cases; and
- fixed typos.