### PR TITLE
TEST: Validator tests

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/format/xml/ParseResultImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/format/xml/ParseResultImpl.java
@@ -87,7 +87,12 @@ final class ParseResultImpl implements ParseResult {
 
     @Override
     public boolean isRootName(final String name) {
-        return this.rootName != null && !this.rootName.isBlank() && this.rootName.equals(name);
+        Objects.requireNonNull(name, "String parameter name cannot be null.");
+        if (this.rootName == null || (name.contains(":") && this.rootPrefix == null)) {
+            return false;
+        }
+        String match = (name.contains(":")) ? String.format("%s:%s", this.rootPrefix, this.rootName) : this.rootName;
+        return match.equals(name);
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -106,6 +106,7 @@ public class Validator {
             OdfPackage pckg = parser.parsePackage(toValidate);
             return parser.validatePackage(pckg);
     }
+
     private ValidationReport validateOpenDocumentXml(final Path toValidate) throws ParserConfigurationException, SAXException, IOException {
         final XmlParser checker = new XmlParser();
         ParseResult parseResult = checker.parse(toValidate);

--- a/odf-core/src/test/java/org/openpreservation/format/xml/ParseResultTest.java
+++ b/odf-core/src/test/java/org/openpreservation/format/xml/ParseResultTest.java
@@ -77,13 +77,17 @@ public class ParseResultTest {
     @Test
     public void testIsRootNameNull() {
         ParseResult parseResult = ParseResultImpl.of(true, XmlTestUtils.exampleNamespace, new ArrayList<>(), "rootPrefix", null, new ArrayList<>(), new ArrayList<>());
-        assertFalse("Null String should not match root name.", parseResult.isRootName(null));
+            assertThrows("NullPointerException expected",
+            NullPointerException.class,
+            () -> {
+                parseResult.isRootName(null);
+            });
     }
 
     @Test
     public void testIsRootNameEmpty() {
         ParseResult parseResult = ParseResultImpl.of(true, XmlTestUtils.exampleNamespace, new ArrayList<>(), "rootPrefix", "", new ArrayList<>(), new ArrayList<>());
-        assertFalse("Empty String should not match root name.", parseResult.isRootName(""));
+        assertTrue("Empty String should match root name.", parseResult.isRootName(""));
     }
 
     @Test

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
@@ -17,11 +17,8 @@ import java.nio.file.Paths;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
-import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.xml.sax.SAXException;
 
 public class ValidatingParserTest {

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
@@ -1,0 +1,203 @@
+package org.openpreservation.odf.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.junit.Test;
+import org.openpreservation.odf.fmt.TestFiles;
+import org.xml.sax.SAXException;
+
+public class ValidatorTest {
+
+    @Test
+    public void validateNullPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        Path nullPath = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    validator.validate(nullPath);
+                });
+    }
+
+    @Test
+    public void validateNoSuchPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        Path noSuchFile = Paths.get("n0SuchDF1l3");
+        assertThrows("FileNotFoundException expected",
+                FileNotFoundException.class,
+                () -> {
+                    validator.validate(noSuchFile);
+                });
+    }
+
+    @Test
+    public void validateDirPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        Path noSuchFile = Paths.get(".");
+        assertThrows("IllegalArgumentException expected",
+        IllegalArgumentException.class,
+                () -> {
+                    validator.validate(noSuchFile);
+                });
+    }
+
+    @Test
+    public void validatePath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.EMPTY_ODS.toURI()).toPath());
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateNullFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        File nullFile = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    validator.validate(nullFile);
+                });
+    }
+
+    @Test
+    public void validateFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.EMPTY_ODS.toURI()));
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateEmpty() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.EMPTY.toURI()).toPath());
+        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
+    }
+
+    @Test
+    public void validateNoMimeNoRoot() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath());
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateDocXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.EMPTY_FODS.toURI()).toPath());
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateDocInvalidXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath());
+        assertFalse("Document should NOT be valid." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
+    }
+
+    @Test
+    public void validateDocNotWellFormedXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath());
+        assertFalse("Document should NOT be valid." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
+    }
+
+    @Test
+    public void validateSpreadsheetNullPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        Path nullPath = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    validator.validateSpreadsheet(nullPath);
+                });
+    }
+
+    @Test
+    public void validateSpreadsheetPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_ODS.toURI()).toPath());
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateSpreadsheetNullFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        File nullFile = null;
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    validator.validateSpreadsheet(nullFile);
+                });
+    }
+
+    @Test
+    public void validateSpreadsheetFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_ODS.toURI()));
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateSingleFormatInvalid() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.DSIG_INVALID.toURI()).toPath());
+        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
+    }
+
+    @Test
+    public void validateSingleFormatEmpty() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY.toURI()).toPath());
+        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-6")).count());
+    }
+
+    @Test
+    public void validateSingleFormatNoMimeNoRoot() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath());
+        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
+    }
+
+    @Test
+    public void validateSingleFormatDocXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_FODS.toURI()).toPath());
+        assertTrue("Package should be valid." , report.isValid());
+    }
+
+    @Test
+    public void validateSpreadsheetDocInvalidXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath());
+        assertFalse("Document should NOT be valid." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
+    }
+
+    @Test
+    public void validateSpreadsheetDocNotWellFormedXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+        Validator validator = new Validator();
+        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath());
+        assertFalse("Document should NOT be valid." , report.isValid());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
+        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
+    }
+}

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorsTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorsTest.java
@@ -1,20 +1,14 @@
 package org.openpreservation.odf.validation;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.openpreservation.format.zip.ZipEntry;
 import org.openpreservation.format.zip.Zips;
-import org.openpreservation.odf.fmt.TestFiles;
 import org.xml.sax.SAXException;
 
 public class ValidatorsTest {
@@ -40,15 +34,5 @@ public class ValidatorsTest {
     public void testInValidCompression() {
         ZipEntry entry = Zips.zipEntryInstance("name", 0, 0, 0, java.util.zip.ZipEntry.CENATT, false, null);
         assertFalse("CENATT should NOT be valid", Validators.isCompressionValid(entry));
-    }
-
-    @Test
-    public void validateSpecificFormat() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
-        Validator validator = new Validator();
-        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_ODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
-        report = validator.validateSpreadsheet(new File(TestFiles.DSIG_INVALID.toURI()).toPath());
-        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
-        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
     }
 }


### PR DESCRIPTION
- fix to make `ParseResultImpl.isRootName()` smarter;
- dedicated and better tests for `Validator` class; and
- tidied redundant tests in `ValidatorsTest`.