### PR TITLE
FEAT: Schematron profile rules

### DIFF
--- a/odf-core/pom.xml
+++ b/odf-core/pom.xml
@@ -41,6 +41,17 @@
         <artifactId>equalsverifier</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.helger.schematron</groupId>
+      <artifactId>ph-schematron-pure</artifactId>
+      <version>7.1.2</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/net.sf.saxon/Saxon-HE -->
+    <dependency>
+        <groupId>net.sf.saxon</groupId>
+        <artifactId>Saxon-HE</artifactId>
+        <version>12.3</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackage.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackage.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.format.zip.ZipArchive;
@@ -114,6 +115,15 @@ public interface OdfPackage {
      *         documents
      */
     public List<String> getXmlEntryPaths();
+
+    /**
+     * Get the paths to all of the identified ODF XML documents in the package,
+     * including content, styles, metadata and the manifest
+     *
+     * @return a List of all of the String internal paths to the packge ODF XML
+     *         documents
+     */
+    public Set<FileEntry> getXmlEntries();
 
     /**
      * Get the InputStream for any item from the document's Manifest

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -7,10 +7,12 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.format.zip.ZipArchive;
@@ -192,6 +194,15 @@ final class OdfPackageImpl implements OdfPackage {
             }
         }
         return paths;
+    }
+
+    @Override
+    public Set<FileEntry> getXmlEntries() {
+        Set<FileEntry> entries = new HashSet<>();
+        for (FileEntry entry : this.manifest.getEntriesByMediaType("text/xml")) {
+            entries.add(entry);
+        }
+        return entries;
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackages.java
@@ -74,6 +74,10 @@ public final class OdfPackages {
         return PackageParserImpl.isDsig(path);
     }
 
+    public static final boolean isOdfXml(final String entrypath) {
+        return PackageParserImpl.isOdfXml(entrypath);
+    }
+
     private OdfPackages() {
         throw new AssertionError("Utility class 'OdfPackages' should not be instantiated");
     }

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParserImpl.java
@@ -153,7 +153,7 @@ final class PackageParserImpl implements PackageParser {
         }
     }
 
-    private final boolean isOdfXml(final String entrypath) {
+    static final boolean isOdfXml(final String entrypath) {
         return Constants.ODF_XML.contains(new File(entrypath).getName());
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
@@ -10,6 +10,7 @@ public interface Rule {
     public String getId();
     public String getName();
     public String getDescription();
+    public boolean isPrerequisite();
     public MessageLog check(final OdfXmlDocument document) throws IOException;
     public MessageLog check(final OdfPackage odfPackage) throws IOException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
@@ -1,17 +1,21 @@
 package org.openpreservation.odf.validation.rules;
 
+import java.util.Objects;
+
 import org.openpreservation.odf.validation.Rule;
 
 abstract class AbstractRule implements Rule {
     final String id;
     final String name;
     final String description;
+    final Boolean isPrerequisite;
 
-    AbstractRule(final String id, final String name, final String description) {
+    AbstractRule(final String id, final String name, final String description, final boolean isPrerequisite) {
         super();
         this.id = id;
         this.name = name;
         this.description = description;
+        this.isPrerequisite = Boolean.valueOf(isPrerequisite);
     }
 
     @Override
@@ -27,5 +31,27 @@ abstract class AbstractRule implements Rule {
     @Override
     public String getDescription() {
         return this.description;
+    }
+
+    @Override
+    public boolean isPrerequisite() {
+        return this.isPrerequisite.booleanValue();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Objects.hash(id, name, description, isPrerequisite);
+    }
+
+    @Override
+    public final boolean equals(final Object obj) {
+        if (this == obj)
+            return true;
+        if (!(obj instanceof AbstractRule))
+            return false;
+        final AbstractRule other = (AbstractRule) obj;
+        return Objects.equals(id, other.id) && Objects.equals(name, other.name)
+                && Objects.equals(description, other.description)
+                && Objects.equals(isPrerequisite, other.isPrerequisite);
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
@@ -11,19 +11,19 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class DigitalSignaturesRule extends AbstractRule {
 
-    private DigitalSignaturesRule(String id, String name, String description) {
-        super(id, name, description);
+    private DigitalSignaturesRule(final String id, final String name, final String description, final boolean isPrerequisite) {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(OdfXmlDocument document) {
+    public MessageLog check(final OdfXmlDocument document) {
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        MessageLog messageLog = Messages.messageLogInstance();
+        final MessageLog messageLog = Messages.messageLogInstance();
         if (odfPackage.hasDsigEntries()) {
             messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(),
                     this.getDescription()));
@@ -33,6 +33,6 @@ final class DigitalSignaturesRule extends AbstractRule {
 
     static final DigitalSignaturesRule getInstance() {
         return new DigitalSignaturesRule("ODF_9", "Digital Signatures",
-                "The package MUST NOT contain any digital signatures.");
+                "The package MUST NOT contain any digital signatures.", false);
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
@@ -12,33 +12,33 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class EncryptionRule extends AbstractRule {
 
-    private EncryptionRule(String id, String name, String description) {
-        super(id, name, description);
+    static final EncryptionRule getInstance() {
+        return new EncryptionRule("ODF_1", "Encryption",
+                "The package MUST NOT contain any encrypted entries.", true);
+    }
+
+    private EncryptionRule(final String id, final String name, final String description, final boolean isPrerequisite) {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(OdfXmlDocument document) {
+    public MessageLog check(final OdfXmlDocument document) {
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        MessageLog messageLog = Messages.messageLogInstance();
+        final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasManifest()) {
             return messageLog;
         }
-        for (FileEntry entry : odfPackage.getManifest().getEntries()) {
+        for (final FileEntry entry : odfPackage.getManifest().getEntries()) {
             if (entry.isEncrypted()) {
                 messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(),
                         this.getDescription()));
             }
         }
         return messageLog;
-    }
-
-    static final EncryptionRule getInstance() {
-        return new EncryptionRule("ODF_1", "Encryption",
-                "The package MUST NOT contain any encrypted entries.");
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
@@ -11,19 +11,26 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class ExtensionMimeTypeRule extends AbstractRule {
 
-    private ExtensionMimeTypeRule(String id, String name, String description) {
-        super(id, name, description);
+    static final ExtensionMimeTypeRule getInstance() {
+        return new ExtensionMimeTypeRule("ODF_4", "Extension and MIME type",
+                "The MIME type value MUST be: \"application/vnd.oasis.opendocument.spreadsheet\" and the file extension MUST be \".ods\"."
+                        + //
+                        "", false);
+    }
+
+    private ExtensionMimeTypeRule(final String id, final String name, final String description, final boolean isPrerequisite) {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(OdfXmlDocument document) {
+    public MessageLog check(final OdfXmlDocument document) {
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        MessageLog messageLog = Messages.messageLogInstance();
+        final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasMimeEntry()
                 || !"application/vnd.oasis.opendocument.spreadsheet".equals(odfPackage.getMimeType())
                 || !odfPackage.getName().endsWith(".ods")) {
@@ -31,12 +38,5 @@ final class ExtensionMimeTypeRule extends AbstractRule {
                     this.getDescription()));
         }
         return messageLog;
-    }
-
-    static final ExtensionMimeTypeRule getInstance() {
-        return new ExtensionMimeTypeRule("ODF_4", "Extension and MIME type",
-                "The MIME type value MUST be: \"application/vnd.oasis.opendocument.spreadsheet\" and the file extension MUST be \".ods\"."
-                        + //
-                        "");
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
@@ -11,26 +11,29 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class PackageMimeTypeRule extends AbstractRule {
 
-    private PackageMimeTypeRule(String id, String name, String description) {
-        super(id, name, description);
+    static final PackageMimeTypeRule getInstance() {
+        return new PackageMimeTypeRule("ODF_3", "Package mimetype entry",
+                "An ODF package MUST have a mimetype entry as specified in the Section 3.3 of the ODF specification v1.3.",
+                false);
+    }
+
+    private PackageMimeTypeRule(final String id, final String name, final String description, final boolean isPrerequisite) {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(OdfXmlDocument document) {
+    public MessageLog check(final OdfXmlDocument document) {
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        MessageLog messageLog = Messages.messageLogInstance();
+        final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasMimeEntry()) {
-            messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(), this.getDescription()));
+            messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(),
+                    this.getDescription()));
         }
         return messageLog;
-    }
-
-    static final PackageMimeTypeRule getInstance() {
-        return new PackageMimeTypeRule("ODF_3", "Package mimetype entry", "An ODF package MUST have a mimetype entry as specified in the Section 3.3 of the ODF specification v1.3.");
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
@@ -6,9 +6,9 @@ import org.openpreservation.odf.validation.Rule;
 import org.xml.sax.SAXException;
 
 public class Rules {
-    private Rules() {
-        throw new AssertionError("Utility class must not be instantiated");
-    }
+    static final String ODF5_SCHEMATRON = "org/openpreservation/odf/core/odf/validation/rules/odf-5.sch";
+    static final String ODF7_SCHEMATRON = "org/openpreservation/odf/core/odf/validation/rules/odf-7.sch";
+    static final String ODF8_SCHEMATRON = "org/openpreservation/odf/core/odf/validation/rules/odf-8.sch";
 
     public static final Rule odf1() {
         return EncryptionRule.getInstance();
@@ -26,11 +26,33 @@ public class Rules {
         return ExtensionMimeTypeRule.getInstance();
     }
 
+    public static final Rule odf5() {
+        return SchematronRule.getInstance("ODF_5", "External data check",
+                "The file MUST NOT have any references to external data.", false,
+                ClassLoader.getSystemResource(ODF5_SCHEMATRON));
+    }
+
+    public static final Rule odf7() {
+        return SchematronRule.getInstance("ODF_7", "Content check",
+                "The file MUST have values or objects in at least one cell.", false,
+                ClassLoader.getSystemResource(ODF7_SCHEMATRON));
+    }
+
+    public static final Rule odf8() {
+        return SchematronRule.getInstance("ODF_8", "Macros check",
+                "The file MUST NOT contain any macros.", false,
+                ClassLoader.getSystemResource(ODF8_SCHEMATRON));
+    }
+
     public static final Rule odf9() {
         return DigitalSignaturesRule.getInstance();
     }
 
     public static final Rule odf10() {
         return SubDocumentRule.getInstance();
+    }
+
+    private Rules() {
+        throw new AssertionError("Utility class must not be instantiated");
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
@@ -1,0 +1,61 @@
+package org.openpreservation.odf.validation.rules;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Objects;
+
+import javax.xml.transform.stream.StreamSource;
+
+import org.openpreservation.messages.Message;
+import org.openpreservation.messages.MessageLog;
+import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.pkg.FileEntry;
+import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.xml.OdfXmlDocument;
+
+import com.helger.schematron.pure.SchematronResourcePure;
+import com.helger.schematron.svrl.AbstractSVRLMessage;
+import com.helger.schematron.svrl.SVRLHelper;
+import com.helger.schematron.svrl.jaxb.SchematronOutputType;
+
+final class SchematronRule extends AbstractRule {
+    static final SchematronRule getInstance(final String id, final String name, final String description, final boolean isPrerequisite, final URL schematronLoc) {
+        return new SchematronRule(id, name, description, isPrerequisite, schematronLoc);
+    }
+
+    final SchematronResourcePure schematron;
+
+    private SchematronRule(final String id, final String name, final String description, final boolean isPrerequisite, final URL schematronLoc) {
+        super(id, name, description, isPrerequisite);
+        this.schematron = SchematronResourcePure.fromURL(schematronLoc);
+    }
+
+    @Override
+    public MessageLog check(final OdfXmlDocument document) throws IOException {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'check'");
+    }
+
+    @Override
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+        final MessageLog messageLog = Messages.messageLogInstance();
+        for (final FileEntry entry : odfPackage.getXmlEntries()) {
+            if (!OdfPackages.isOdfXml(entry.getFullPath())) {
+                continue;
+            }
+            try (InputStream is = odfPackage.getEntryStream(entry)) {
+                final SchematronOutputType schResult = this.schematron.applySchematronValidationToSVRL(new StreamSource(is));
+                for (final AbstractSVRLMessage result : SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult)) {
+                    messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(),
+                result.getText()));
+                }
+            } catch (final Exception e) {
+                throw new IOException(e);
+            }
+        }
+        return messageLog;
+    }
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
@@ -11,28 +11,28 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class SubDocumentRule extends AbstractRule {
 
-    private SubDocumentRule(String id, String name, String description) {
-        super(id, name, description);
+    static final SubDocumentRule getInstance() {
+        return new SubDocumentRule("ODF_10", "Sub Documents",
+                "The package MUST NOT contain sub documents.", false);
+    }
+
+    private SubDocumentRule(final String id, final String name, final String description, final boolean isPrerequisite) {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(OdfXmlDocument document) {
+    public MessageLog check(final OdfXmlDocument document) {
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws IOException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        MessageLog messageLog = Messages.messageLogInstance();
+        final MessageLog messageLog = Messages.messageLogInstance();
         if (odfPackage.hasManifest() && odfPackage.getManifest().getDocumentEntries().size() > 1) {
             messageLog.add(Messages.getMessageInstance(this.id, Message.Severity.ERROR, this.getName(),
                     this.getDescription()));
         }
         return messageLog;
-    }
-
-    static final SubDocumentRule getInstance() {
-        return new SubDocumentRule("ODF_10", "Sub Documents",
-                "The package MUST NOT contain sub documents.");
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
@@ -18,8 +18,8 @@ import org.xml.sax.SAXException;
 class ValidPackageRule extends AbstractRule {
     private final ValidatingParser validatingParser = Validators.getValidatingParser();
 
-    private ValidPackageRule(String id, String name, String description) throws ParserConfigurationException, SAXException {
-        super(id, name, description);
+    private ValidPackageRule(String id, String name, String description, final boolean isPrerequisite) throws ParserConfigurationException, SAXException {
+        super(id, name, description, isPrerequisite);
     }
 
     @Override
@@ -40,6 +40,6 @@ class ValidPackageRule extends AbstractRule {
     }
 
     static final ValidPackageRule getInstance() throws ParserConfigurationException, SAXException {
-        return new ValidPackageRule("ODF_2", "Standard Compliance", "The file MUST comply with the standard \"OASIS Open Document Format for Office Applications (OpenDocument) v1.3\".");
+        return new ValidPackageRule("ODF_2", "Standard Compliance", "The file MUST comply with the standard \"OASIS Open Document Format for Office Applications (OpenDocument) v1.3\".", true);
     }
 }

--- a/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-5.sch
+++ b/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-5.sch
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <ns prefix="office" uri="urn:oasis:names:tc:opendocument:xmlns:office:1.0" />
+  <ns prefix="table" uri="urn:oasis:names:tc:opendocument:xmlns:table:1.0" />
+  <ns prefix="form" uri="urn:oasis:names:tc:opendocument:xmlns:form:1.0" />
+  <ns prefix="text" uri="urn:oasis:names:tc:opendocument:xmlns:text:1.0" />
+  <pattern id="ODF_5">
+    <title>External data check</title>
+    <rule context="//office:document-content">
+      <assert id="ODF_5.1" role="ERROR" test="count(//table:dde-links) &lt; 1">Table Dynamic Data Exchange link declarations detected.</assert>
+      <assert id="ODF_5.2" role="ERROR" test="count(//office:dde-source) &lt; 1">Dynamic Data Exchange connection detected.</assert>
+      <assert id="ODF_5.3" role="ERROR" test="count(//table:table-cell[@table:formula]) &lt; 1">Table formula detected.</assert>
+      <assert id="ODF_5.4" role="ERROR" test="count(//form:connection-resource) &lt; 1">Form connection resource detected.</assert>
+      <assert id="ODF_5.5" role="ERROR" test="count(//table:table-source) &lt; 1">Table source detected.</assert>
+      <assert id="ODF_5.6" role="ERROR" test="count(//table:cell-range-source) &lt; 1">Table cell-range source detected.</assert>
+      <assert id="ODF_5.7" role="ERROR" test="count(//table:database-source-sql) &lt; 1">SQL database source detected.</assert>
+      <assert id="ODF_5.8" role="ERROR" test="count(//table:database-source-table) &lt; 1">Table database source detected.</assert>
+      <assert id="ODF_5.9" role="ERROR" test="count(//table:database-source-query) &lt; 1">Query database source detected.</assert>
+      <assert id="ODF_5.10" role="ERROR" test="count(//text:dde-connection-decls) &lt; 1">Dynamic Data Exchange declarations detected.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-7.sch
+++ b/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-7.sch
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <ns prefix="office" uri="urn:oasis:names:tc:opendocument:xmlns:office:1.0" />
+  <ns prefix="table" uri="urn:oasis:names:tc:opendocument:xmlns:table:1.0" />
+  <pattern id="ODF_7">
+    <title>Content check</title>
+    <rule context="//office:spreadsheet">
+      <assert id="ODF_7.1" role="ERROR" test="count(table:table/table:table-row/table:table-cell[@office:value-type]) > 0 or count(table:table/table:table-row/table:covered-table-cell[@office:value-type]) > 0">The file MUST have values or objects in at least one cell.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-8.sch
+++ b/odf-core/src/main/resources/org/openpreservation/odf/core/odf/validation/rules/odf-8.sch
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://purl.oclc.org/dsdl/schematron">
+  <ns prefix="office" uri="urn:oasis:names:tc:opendocument:xmlns:office:1.0" />
+  <ns prefix="table" uri="urn:oasis:names:tc:opendocument:xmlns:table:1.0" />
+  <ns prefix="script" uri="urn:oasis:names:tc:opendocument:xmlns:script:1.0" />
+  <pattern id="ODF_8">
+    <title>Macro check</title>
+    <rule context="//office:document-content">
+      <assert id="ODF_8.1" role="ERROR" test="count(//script:event-listener) &lt; 1">The spreadsheet MUST NOT reference any macros.</assert>
+    </rule>
+  </pattern>
+</schema>

--- a/odf-core/src/test/resources/org/openpreservation/odf/fmt/xml/content.xml
+++ b/odf-core/src/test/resources/org/openpreservation/odf/fmt/xml/content.xml
@@ -1,2 +1,66 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<office:document-content xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0" xmlns:css3t="http://www.w3.org/TR/css3-text/" xmlns:grddl="http://www.w3.org/2003/g/data-view#" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:rpt="http://openoffice.org/2005/report" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0" xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0" xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0" xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0" xmlns:oooc="http://openoffice.org/2004/calc" xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0" xmlns:ooow="http://openoffice.org/2004/writer" xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0" xmlns:ooo="http://openoffice.org/2004/office" xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0" xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0" xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0" xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0" xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2" xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0" xmlns:tableooo="http://openoffice.org/2009/table" xmlns:drawooo="http://openoffice.org/2010/draw" xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0" xmlns:dom="http://www.w3.org/2001/xml-events" xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:math="http://www.w3.org/1998/Math/MathML" xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0" xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0" xmlns:xforms="http://www.w3.org/2002/xforms" office:version="1.3"><office:scripts/><office:font-face-decls><style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/><style:font-face style:name="Lohit Devanagari" svg:font-family="&apos;Lohit Devanagari&apos;" style:font-family-generic="system" style:font-pitch="variable"/><style:font-face style:name="Noto Sans CJK SC" svg:font-family="&apos;Noto Sans CJK SC&apos;" style:font-family-generic="system" style:font-pitch="variable"/></office:font-face-decls><office:automatic-styles><style:style style:name="co1" style:family="table-column"><style:table-column-properties fo:break-before="auto" style:column-width="2.258cm"/></style:style><style:style style:name="ro1" style:family="table-row"><style:table-row-properties style:row-height="0.452cm" fo:break-before="auto" style:use-optimal-row-height="true"/></style:style><style:style style:name="ta1" style:family="table" style:master-page-name="Default"><style:table-properties table:display="true" style:writing-mode="lr-tb"/></style:style></office:automatic-styles><office:body><office:spreadsheet><table:calculation-settings table:automatic-find-labels="false" table:use-regular-expressions="false" table:use-wildcards="true"/><table:table table:name="Sheet1" table:style-name="ta1"><table:table-column table:style-name="co1" table:default-cell-style-name="Default"/><table:table-row table:style-name="ro1"><table:table-cell/></table:table-row></table:table><table:named-expressions/></office:spreadsheet></office:body></office:document-content>
+<office:document-content xmlns:presentation="urn:oasis:names:tc:opendocument:xmlns:presentation:1.0"
+    xmlns:css3t="http://www.w3.org/TR/css3-text/"
+    xmlns:grddl="http://www.w3.org/2003/g/data-view#"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns:formx="urn:openoffice:names:experimental:ooxml-odf-interop:xmlns:form:1.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns:rpt="http://openoffice.org/2005/report"
+    xmlns:dc="http://purl.org/dc/elements/1.1/"
+    xmlns:chart="urn:oasis:names:tc:opendocument:xmlns:chart:1.0"
+    xmlns:svg="urn:oasis:names:tc:opendocument:xmlns:svg-compatible:1.0"
+    xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"
+    xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"
+    xmlns:oooc="http://openoffice.org/2004/calc"
+    xmlns:style="urn:oasis:names:tc:opendocument:xmlns:style:1.0"
+    xmlns:ooow="http://openoffice.org/2004/writer"
+    xmlns:meta="urn:oasis:names:tc:opendocument:xmlns:meta:1.0"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:fo="urn:oasis:names:tc:opendocument:xmlns:xsl-fo-compatible:1.0"
+    xmlns:ooo="http://openoffice.org/2004/office"
+    xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"
+    xmlns:dr3d="urn:oasis:names:tc:opendocument:xmlns:dr3d:1.0"
+    xmlns:table="urn:oasis:names:tc:opendocument:xmlns:table:1.0"
+    xmlns:number="urn:oasis:names:tc:opendocument:xmlns:datastyle:1.0"
+    xmlns:of="urn:oasis:names:tc:opendocument:xmlns:of:1.2"
+    xmlns:calcext="urn:org:documentfoundation:names:experimental:calc:xmlns:calcext:1.0"
+    xmlns:tableooo="http://openoffice.org/2009/table"
+    xmlns:drawooo="http://openoffice.org/2010/draw"
+    xmlns:loext="urn:org:documentfoundation:names:experimental:office:xmlns:loext:1.0"
+    xmlns:dom="http://www.w3.org/2001/xml-events"
+    xmlns:field="urn:openoffice:names:experimental:ooo-ms-interop:xmlns:field:1.0"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:math="http://www.w3.org/1998/Math/MathML"
+    xmlns:form="urn:oasis:names:tc:opendocument:xmlns:form:1.0"
+    xmlns:script="urn:oasis:names:tc:opendocument:xmlns:script:1.0"
+    xmlns:xforms="http://www.w3.org/2002/xforms" office:version="1.3">
+    <office:scripts/>
+    <office:font-face-decls>
+        <style:font-face style:name="Liberation Sans" svg:font-family="&apos;Liberation Sans&apos;" style:font-family-generic="swiss" style:font-pitch="variable"/>
+        <style:font-face style:name="Lohit Devanagari" svg:font-family="&apos;Lohit Devanagari&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+        <style:font-face style:name="Noto Sans CJK SC" svg:font-family="&apos;Noto Sans CJK SC&apos;" style:font-family-generic="system" style:font-pitch="variable"/>
+    </office:font-face-decls>
+    <office:automatic-styles>
+        <style:style style:name="co1" style:family="table-column">
+            <style:table-column-properties fo:break-before="auto" style:column-width="2.258cm"/>
+        </style:style>
+        <style:style style:name="ro1" style:family="table-row">
+            <style:table-row-properties style:row-height="0.452cm" fo:break-before="auto" style:use-optimal-row-height="true"/>
+        </style:style>
+        <style:style style:name="ta1" style:family="table" style:master-page-name="Default">
+            <style:table-properties table:display="true" style:writing-mode="lr-tb"/>
+        </style:style>
+    </office:automatic-styles>
+    <office:body>
+        <office:spreadsheet>
+            <table:calculation-settings table:automatic-find-labels="false" table:use-regular-expressions="false" table:use-wildcards="true"/>
+            <table:table table:name="Sheet1" table:style-name="ta1">
+                <table:table-column table:style-name="co1" table:default-cell-style-name="Default"/>
+                <table:table-row table:style-name="ro1">
+                    <table:table-cell/>
+                </table:table-row>
+            </table:table>
+            <table:named-expressions/>
+        </office:spreadsheet>
+    </office:body>
+</office:document-content>


### PR DESCRIPTION
- added `SchematronRule` class to handle rules encoded as Schematron;
- added schematron rules for for `ODF_5`, `ODF_7` and `ODF_8`;
- added instatiation methods for `ODF_5`, `ODF_7` and `ODF_8` SchematronRules to `Rules`;
- added prerequisite flag to `Rule` for profile sequencing;
- working Hash and Equals for `AbstractRule`;
- convenience method to get set of XML entries from `OdfPackage`;
- convenience method to identify XML entries in `OdfPackages`;
- tidied some compiler warnings, unused imports and the like; and
- added schematron dependencies to `odf-core/pom.xml`.