### PR TITLE
REFACT: Tidying parser loose ends

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
@@ -29,6 +29,7 @@ final class SchematronRule extends AbstractRule {
 
     private SchematronRule(final String id, final String name, final String description, final boolean isPrerequisite, final URL schematronLoc) {
         super(id, name, description, isPrerequisite);
+        Objects.requireNonNull(schematronLoc, "schematronLoc must not be null");
         this.schematron = SchematronResourcePure.fromURL(schematronLoc);
     }
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -56,7 +57,9 @@ public class ContentTest {
     @Test
     public void testSchematronContentFail() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf7()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml")));
+        final URL resource = ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml");
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(1, results.size());
@@ -65,7 +68,9 @@ public class ContentTest {
     @Test
     public void testSchematronContentPass() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf7()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(TestFiles.SCHEMATRON_CHECKER_XML));
+        final URL resource = TestFiles.SCHEMATRON_CHECKER_XML;
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(0, results.size());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -56,7 +57,9 @@ public class ExternalDataTest {
     @Test
     public void testSchematronExternalDataFail() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf5()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(TestFiles.SCHEMATRON_CHECKER_XML));
+        final URL resource = TestFiles.SCHEMATRON_CHECKER_XML;
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(1, results.size());
@@ -65,7 +68,9 @@ public class ExternalDataTest {
     @Test
     public void testSchematronExternalDataPass() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf5()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml")));
+        final URL resource = ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml");
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(0, results.size());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 
@@ -56,7 +57,9 @@ public class MacrosTest {
     @Test
     public void testSchematronRuleMacroFail() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf8()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(TestFiles.MACRO_XML));
+        final URL resource = TestFiles.MACRO_XML;
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(1, results.size());
@@ -65,7 +68,9 @@ public class MacrosTest {
     @Test
     public void testSchematronNoMacroPass() throws Exception {
         final SchematronResourcePure schematron = ((SchematronRule) Rules.odf8()).schematron;
-        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml")));
+        final URL resource = ClassLoader.getSystemResource("org/openpreservation/odf/fmt/xml/content.xml");
+        assertNotNull(resource);
+        final SchematronOutputType schResult = schematron.applySchematronValidationToSVRL(new URLResource(resource));
         assertNotNull(schResult);
         List<AbstractSVRLMessage> results = SVRLHelper.getAllFailedAssertionsAndSuccessfulReports(schResult);
         assertEquals(0, results.size());


### PR DESCRIPTION
- better used of member vars;
- simplified manifest parsing; and
- better null tests.