### PR TITLE
FEAT: Test encrypted entry is STORED

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipEntry.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipEntry.java
@@ -5,6 +5,7 @@ public interface ZipEntry {
     public long getSize();
     public long getCompressedSize();
     public long getCrc();
+    public boolean isStored();
     public int getMethod();
     public boolean isDirectory();
     public byte[] getExtra();

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipEntryImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipEntryImpl.java
@@ -72,6 +72,11 @@ public final class ZipEntryImpl implements ZipEntry {
     }
 
     @Override
+    public boolean isStored() {
+        return this.getMethod() == java.util.zip.ZipEntry.STORED;
+    }
+
+    @Override
     public int getMethod() {
         return this.method;
     }
@@ -134,5 +139,4 @@ public final class ZipEntryImpl implements ZipEntry {
         return "ZipEntryImpl [name=" + name + ", size=" + size + ", compressedSize=" + compressedSize + ", crc=" + crc
                 + ", method=" + method + ", isDirectory=" + isDirectory + "]";
     }
-
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/Manifest.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/Manifest.java
@@ -10,6 +10,12 @@ public interface Manifest {
     public String getVersion();
 
     /**
+     * Find out whether the manifest has a FileEntry with the full path attribute "/".
+     * @return true if a root element .
+     */
+    public boolean hasRootMediaType();
+
+    /**
      * Get the declared media type of the Manifest from the root "/" element.
      * @return the declared media type of the Manifest.
      */
@@ -39,6 +45,13 @@ public interface Manifest {
      * @return the Set of FileEntry objects that have the supplied media type.
      */
     public Set<FileEntry> getEntriesByMediaType(final String mediaType);
+
+    /**
+     * Get the Set of FileEntry objects fior all manifest entries with encryption XML data.
+     * @param mediaType the media type to filter the entries by.
+     * @return the Set of FileEntry objects that have encryption XML data.
+     */
+    public Set<FileEntry> getEncryptedEntries();
 
     /**
      * Get a manifest entry by name

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/ManifestImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/ManifestImpl.java
@@ -109,6 +109,11 @@ final class ManifestImpl implements Manifest {
     }
 
     @Override
+    public boolean hasRootMediaType() {
+        return this.hasRoot;
+    }
+
+    @Override
     public String getRootMediaType() {
         return this.hasRoot ? this.getEntry("/").getMediaType() : null;
     }
@@ -132,6 +137,11 @@ final class ManifestImpl implements Manifest {
     public Set<FileEntry> getEntriesByMediaType(final String mediaType) {
         return this.entries.values().stream().filter(e -> e.getMediaType().equals(mediaType))
                 .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<FileEntry> getEncryptedEntries() {
+        return this.entries.values().stream().filter(e -> e.isEncrypted()).collect(Collectors.toSet());
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
@@ -172,7 +172,7 @@ final class ValidatingParserImpl implements ValidatingParser {
         if (!isFirst) {
             messages.add(FACTORY.getError("MIM-1"));
         }
-        if (mimeEntry.getMethod() != java.util.zip.ZipEntry.STORED) {
+        if (!mimeEntry.isStored()) {
             messages.add(FACTORY.getError("MIM-2"));
         }
         if (mimeEntry.getExtra() != null && mimeEntry.getExtra().length > 0) {
@@ -185,7 +185,11 @@ final class ValidatingParserImpl implements ValidatingParser {
     private List<Message> validateManifest(final OdfPackage odfPackage) {
         final List<Message> messages = new ArrayList<>();
         Manifest manifest = odfPackage.getManifest();
-        if (manifest != null && manifest.getEntry("/") == null) {
+        if (manifest == null || !odfPackage.hasManifest()) {
+            messages.add(FACTORY.getError("PKG-3"));
+            return messages;
+        }
+        if (manifest.getEntry("/") == null) {
             if (!odfPackage.hasMimeEntry()) {
                 messages.add(FACTORY.getWarning("MAN-7"));
             } else {
@@ -195,9 +199,7 @@ final class ValidatingParserImpl implements ValidatingParser {
                 && !manifest.getRootMediaType().equals(odfPackage.getMimeType()))) {
             messages.add(FACTORY.getError("MIM-5", manifest.getRootMediaType(), odfPackage.getMimeType()));
         }
-        if (manifest != null) {
-            messages.addAll(checkManifestEntries(odfPackage));
-        }
+        messages.addAll(checkManifestEntries(odfPackage));
         return messages;
     }
 
@@ -209,15 +211,16 @@ final class ValidatingParserImpl implements ValidatingParser {
         final List<Message> messages = new ArrayList<>();
         for (FileEntry entry : odfPackage.getManifest().getEntries()) {
             final String entryPath = entry.getFullPath();
+            ZipEntry zipEntry = odfPackage.getZipArchive().getZipEntry(entryPath);
             if ("/".equals(entryPath) || entryPath.endsWith("/")) {
                 // do nothing
             } else if (!isLegitimateManifestEntry(entryPath)) {
                 messages.add(getManifestError(entryPath));
-            } else {
-                ZipEntry zipEntry = odfPackage.getZipArchive().getZipEntry(entryPath);
-                if (zipEntry == null) {
-                    messages.add(FACTORY.getError("MAN-4", entryPath));
-                }
+            } else if (zipEntry == null) {
+                messages.add(FACTORY.getError("MAN-4", entryPath));
+            }
+            if (entry.isEncrypted() && zipEntry != null && !zipEntry.isStored() ) {
+                messages.add(FACTORY.getError("PKG-8", entryPath));
             }
         }
         return messages;
@@ -228,8 +231,7 @@ final class ValidatingParserImpl implements ValidatingParser {
         final Manifest manifest = odfPackage.getManifest();
         for (ZipEntry zipEntry : odfPackage.getZipArchive().getZipEntries()) {
             final List<Message> messages = new ArrayList<>();
-            if ((zipEntry.getMethod() != java.util.zip.ZipEntry.STORED)
-                    && (zipEntry.getMethod() != java.util.zip.ZipEntry.DEFLATED)) {
+            if (!isCompressionValid(zipEntry)) {
                 // Entries SHALL be uncompressesed (Stored) or use deflate compression
                 messages.add(FACTORY.getError("PKG-2", zipEntry.getName()));
             }
@@ -248,6 +250,10 @@ final class ValidatingParserImpl implements ValidatingParser {
             messageMap.put(zipEntry.getName(), messages);
         }
         return messageMap;
+    }
+
+    static final boolean isCompressionValid(final ZipEntry entry) {
+        return entry.getMethod() == java.util.zip.ZipEntry.STORED || entry.getMethod() == java.util.zip.ZipEntry.DEFLATED;
     }
 
     private final boolean isLegitimateManifestEntry(final String entryPath) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validators.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validators.java
@@ -25,7 +25,7 @@ public class Validators {
      * @return true if the compression method is valid, else false
      */
     public static boolean isCompressionValid(final ZipEntry entry) {
-        return entry.getMethod() == java.util.zip.ZipEntry.STORED || entry.getMethod() == java.util.zip.ZipEntry.DEFLATED;
+        return ValidatingParserImpl.isCompressionValid(entry);
     }
 
     private Validators() {


### PR DESCRIPTION
- simplified `Manifest` validation;
- added check to ensure that all encrypted entries are flagged as `STORED`, with PKG-8 ID;
- added `FileEntry` convenience function to check if an entry is stored; and
- added `Manifest` convenience functions to return all encrypted entries and to check if manifest has root entry.