### PR TITLE
FIX: Zip feature detection and exception logging

### DIFF
--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
@@ -10,8 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.openpreservation.messages.Message;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageFactory;
@@ -19,12 +17,12 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.ValidationReport;
 import org.openpreservation.odf.validation.Validator;
 import org.openpreservation.odf.validation.rules.Rules;
-import org.xml.sax.SAXException;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -76,8 +74,9 @@ class CliValidator implements Callable<Integer> {
             return validator.validate(toValidate);
         } catch (IllegalArgumentException | FileNotFoundException e) {
             this.logMessage(toValidate, Messages.getMessageInstance("APP-2", Severity.ERROR, e.getMessage()));
-        } catch (ParserConfigurationException | SAXException | IOException e) {
-            e.printStackTrace();
+        } catch (ParseException e) {
+            this.logMessage(toValidate, Messages.getMessageInstance("SYS-1", Severity.ERROR,
+                    "Package could not be parsed, due to an exception.", e.getMessage()));
         }
         return null;
     }
@@ -87,8 +86,9 @@ class CliValidator implements Callable<Integer> {
             return dnaProfile.check(parser.parsePackage(toProfile));
         } catch (IllegalArgumentException | FileNotFoundException e) {
             this.logMessage(toProfile, Messages.getMessageInstance("APP-2", Severity.ERROR, e.getMessage()));
-        } catch (IOException e) {
-            e.printStackTrace();
+        } catch (ParseException e) {
+            this.logMessage(toProfile, Messages.getMessageInstance("SYS-1", Severity.ERROR,
+                    "Package could not be parsed, due to an exception.", e.getMessage()));
         }
         return null;
     }

--- a/odf-apps/src/main/resources/org/openpreservation/odf/apps/messages/Messages.properties
+++ b/odf-apps/src/main/resources/org/openpreservation/odf/apps/messages/Messages.properties
@@ -6,5 +6,4 @@ APP-5 = %s Profile report for %s.
 SYS-1 = Supplied path could not be read, IO Exception %s.
 SYS-2 = Could not load internal schema %s due to Exception %s.
 SYS-3 = Could not configure SAX parser due to Exception %s.
-
-
+SYS-4 = Package %s could not be parsed, due to an exception.

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchive.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchive.java
@@ -16,7 +16,8 @@ public interface ZipArchive {
     /**
      * Get a <code>List<ZipEntry></code> of all of the zip entries in the archive
      *
-     * @return an ordered <code>List<ZipEntry></code> of all of the zip entries in the archive
+     * @return an ordered <code>List<ZipEntry></code> of all of the zip entries in
+     *         the archive
      */
     public List<ZipEntry> getZipEntries();
 
@@ -25,7 +26,8 @@ public interface ZipArchive {
      *
      * @param entryName the name of the <code>ZipEntry</code> to retrieve
      *
-     * @return the <code>ZipEntry</code> with the given <code>entryName</code>, or <code>null</code> if no match
+     * @return the <code>ZipEntry</code> with the given <code>entryName</code>, or
+     *         <code>null</code> if no match
      */
     public ZipEntry getZipEntry(final String entryName);
 

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveCache.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveCache.java
@@ -5,18 +5,23 @@ import java.io.InputStream;
 import java.util.List;
 
 /**
- * An extension of {@link ZipArchive} that caches the contents of the archive and provides access to the <code>InputStream</code>s.
+ * An extension of {@link ZipArchive} that caches the contents of the archive
+ * and provides access to the <code>InputStream</code>s.
  */
 public interface ZipArchiveCache extends ZipArchive {
     /**
      * Get a <code>List<String></code> of all of the cached entries in the archive
+     *
      * @return
      */
     public List<String> getCachedEntryNames();
 
     /**
-     * Get the <code>InputStream</code> for the entry with the passed name, equivalent to the path.
-     * @return the <code>InputStream</code> for the entry with the passed <code>name</code>, or <code>null</code> if no match
+     * Get the <code>InputStream</code> for the entry with the passed name,
+     * equivalent to the path.
+     *
+     * @return the <code>InputStream</code> for the entry with the passed
+     *         <code>name</code>, or <code>null</code> if no match
      */
     public InputStream getEntryInputStream(final String entryName) throws IOException;
 }

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipFileProcessor.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipFileProcessor.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.openpreservation.utils.Checks;

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -112,7 +112,8 @@ final class OdfPackageImpl implements OdfPackage {
 
     private OdfPackageImpl(final String name, final ZipArchiveCache archive, final Formats format,
             final Version version,
-            final String mimetype, final Manifest manifest, final Map<String, OdfPackageDocument> documentMap,
+            final String mimetype, final Manifest manifest,
+            final Map<String, OdfPackageDocument> documentMap,
             final Map<String, ParseResult> metaInfMap) {
         super();
         this.archive = archive;

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParser.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParser.java
@@ -1,9 +1,11 @@
 package org.openpreservation.odf.pkg;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
+import java.util.Map;
 
 import org.openpreservation.format.zip.ZipArchive;
 
@@ -22,7 +24,7 @@ public interface PackageParser {
      *                              package {@link ZipArchive}.
      * @throws NullPointerException when <code>toParse</code> is null
      */
-    public OdfPackage parsePackage(final Path is) throws IOException;
+    public OdfPackage parsePackage(final Path is) throws ParseException, FileNotFoundException;
 
     /**
      * Parse a Java File instance and return an {@link OdfPackage} instance.
@@ -35,7 +37,7 @@ public interface PackageParser {
      *                              package {@link ZipArchive}
      * @throws NullPointerException when <code>toParse</code> is null
      */
-    public OdfPackage parsePackage(final File toParse) throws IOException;
+    public OdfPackage parsePackage(final File toParse) throws ParseException, FileNotFoundException;
 
     /**
      * Parse an <code>InputStream</code> and return an {@link OdfPackage} instance.
@@ -52,5 +54,33 @@ public interface PackageParser {
      *                              is <code>null</code>
      */
     public OdfPackage parsePackage(final InputStream toParse, final String name)
-            throws IOException;
+            throws ParseException;
+
+    public static class ParseException extends Exception {
+        private static final long serialVersionUID = 1L;
+
+        public ParseException(final String message) {
+            super(message);
+        }
+
+        public ParseException(final Map<String, String> badEntries) {
+            super(messageFromEntryMap(badEntries));
+        }
+
+        public ParseException(final String message, final Throwable cause) {
+            super(message, cause);
+        }
+
+        private static final String messageFromEntryMap(final Map<String, String> badEntries) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("The following zip entries could not be read: ");
+            badEntries.forEach((k, v) -> {
+                sb.append(k);
+                sb.append(": ");
+                sb.append(v);
+                sb.append("\n");
+            });
+            return sb.toString();
+        }
+    }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/PackageParserImpl.java
@@ -2,6 +2,7 @@ package org.openpreservation.odf.pkg;
 
 import java.io.BufferedInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -15,6 +16,9 @@ import java.util.Objects;
 
 import javax.xml.parsers.ParserConfigurationException;
 
+import org.apache.commons.compress.archivers.zip.UnsupportedZipFeatureException;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.format.xml.XmlParser;
 import org.openpreservation.format.zip.ZipArchiveCache;
@@ -31,6 +35,8 @@ import org.xml.sax.SAXException;
 
 final class PackageParserImpl implements PackageParser {
     private static String toParseConst = "toParse";
+    private static String badFeature = "Unsupported Zip feature: %s";
+    private static String ioException = "IO Exception reading stream: %s";
 
     static final PackageParser getInstance() {
         return new PackageParserImpl();
@@ -56,6 +62,7 @@ final class PackageParserImpl implements PackageParser {
             return FormatSniffer.sniff(bis);
         }
     }
+
     private ZipArchiveCache cache;
     private Formats format = Formats.UNKNOWN;
     private String mimetype = "";
@@ -69,34 +76,40 @@ final class PackageParserImpl implements PackageParser {
     }
 
     @Override
-    public OdfPackage parsePackage(final Path toParse) throws IOException {
+    public OdfPackage parsePackage(final Path toParse) throws ParseException, FileNotFoundException {
         Objects.requireNonNull(toParse, String.format(Checks.NOT_NULL, toParseConst, "Path"));
         return this.parsePackage(toParse, toParse.getFileName().toString());
     }
 
     @Override
-    public OdfPackage parsePackage(final File toParse) throws IOException {
+    public OdfPackage parsePackage(final File toParse) throws ParseException, FileNotFoundException {
         Objects.requireNonNull(toParse, String.format(Checks.NOT_NULL, toParseConst, "File"));
         return this.parsePackage(toParse.toPath(), toParse.getName());
     }
 
     @Override
-    public OdfPackage parsePackage(final InputStream toParse, final String name) throws IOException {
+    public OdfPackage parsePackage(final InputStream toParse, final String name) throws ParseException {
         Objects.requireNonNull(toParse, String.format(Checks.NOT_NULL, toParseConst, "InputStream"));
         Objects.requireNonNull(name, String.format(Checks.NOT_NULL, name, "String"));
         try (BufferedInputStream bis = new BufferedInputStream(toParse)) {
             final Path temp = Files.createTempFile("odf", ".pkg");
             Files.copy(bis, temp, StandardCopyOption.REPLACE_EXISTING);
             return this.parsePackage(temp, name);
+        } catch (IOException e) {
+            throw new ParseException("IOException occured when reading package.", e);
         }
     }
 
-    private final OdfPackage parsePackage(final Path toParse, final String name) throws IOException {
+    private final OdfPackage parsePackage(final Path toParse, final String name) throws ParseException, FileNotFoundException {
         Checks.existingFileCheck(toParse);
         this.initialise();
         try {
             this.format = sniff(toParse);
             this.cache = Zips.zipArchiveCacheInstance(toParse);
+            Map<String, String> badEntries = checkZipEntries();
+            if (!badEntries.isEmpty()) {
+                throw new ParseException(badEntries);
+            }
             this.version = detectVersion();
         } catch (final IOException e) {
             // Simply catch the exception and return a sparsely populated OdfPackage
@@ -106,13 +119,28 @@ final class PackageParserImpl implements PackageParser {
             this.processZipEntries();
             return this.makePackage(name);
         } catch (ParserConfigurationException | SAXException e) {
-            throw new IOException(e);
+            throw new ParseException("SAX Exception while parsing package.", e);
+        } catch (IOException e) {
+            throw new ParseException("IOException while parsing package.", e);
         }
     }
 
+    private final Map<String, String> checkZipEntries() {
+        final Map<String, String> badEntries = new HashMap<>();
+        for (ZipEntry entry : this.cache.getZipEntries()) {
+            try {
+                this.cache.getEntryInputStream(entry.getName()).close();
+            } catch (UnsupportedZipFeatureException e) {
+                badEntries.put(entry.getName(), String.format(badFeature, e.getFeature().toString()));
+            } catch (IOException e) {
+                badEntries.put(entry.getName(), String.format(ioException, e.getMessage()));
+            }
+        }
+        return badEntries;
+    }
 
     final Version detectVersion() throws IOException {
-        Version version = Version.UNKNOWN;
+        Version detectedVersion = Version.UNKNOWN;
         try (InputStream is = getVersionStreamName()) {
             if (is != null) {
                 ParseResult result = new XmlParser().parse(is);
@@ -121,7 +149,7 @@ final class PackageParserImpl implements PackageParser {
         } catch (ParserConfigurationException | SAXException e) {
             throw new IOException(e);
         }
-        return version;
+        return detectedVersion;
     }
 
     private final InputStream getVersionStreamName() throws IOException {
@@ -189,6 +217,7 @@ final class PackageParserImpl implements PackageParser {
                 builder.document(docEntry.getFullPath(), makeDocument(docEntry));
             }
         }
+
         for (final Entry<String, OdfXmlDocument> docEntry : this.xmlDocumentMap.entrySet()) {
             if (isMetaInf(docEntry.getKey())) {
                 builder.metaInf(docEntry.getKey(), docEntry.getValue().getParseResult());

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
@@ -1,16 +1,16 @@
 package org.openpreservation.odf.validation;
 
-import java.io.IOException;
 import java.util.Set;
 
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Profile {
     public String getId();
     public String getName();
     public String getDescription();
-    public ProfileResult check(final OdfXmlDocument document) throws IOException;
-    public ProfileResult check(final OdfPackage odfPackage) throws IOException;
+    public ProfileResult check(final OdfXmlDocument document) throws ParseException;
+    public ProfileResult check(final OdfPackage odfPackage) throws ParseException;
     public Set<Rule> getRules();
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Rule {
@@ -13,6 +14,6 @@ public interface Rule {
     public String getDescription();
     public Severity getSeverity();
     public boolean isPrerequisite();
-    public MessageLog check(final OdfXmlDocument document) throws IOException;
-    public MessageLog check(final OdfPackage odfPackage) throws IOException;
+    public MessageLog check(final OdfXmlDocument document) throws ParseException;
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParser.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParser.java
@@ -1,5 +1,6 @@
 package org.openpreservation.odf.validation;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.openpreservation.odf.pkg.OdfPackage;
@@ -8,10 +9,12 @@ import org.openpreservation.odf.pkg.PackageParser;
 public interface ValidatingParser extends PackageParser {
     /**
      * Validates the given ODF package.
+     * 
      * @param odfPackage the ODF Package to validate, this must not be null
      * @return a ValidationReport containing the results of the validation
-     * @throws IOException if there's a problem reading package elements from the zip file.
+     * @throws IOException if there's a problem reading package elements from the
+     *                     zip file.
      */
     public ValidationReport validatePackage(final OdfPackage odfPackage)
-            throws IOException;
+            throws ParseException, FileNotFoundException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
@@ -1,6 +1,7 @@
 package org.openpreservation.odf.validation;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
@@ -70,17 +71,17 @@ final class ValidatingParserImpl implements ValidatingParser {
     }
 
     @Override
-    public OdfPackage parsePackage(Path toParse) throws IOException {
+    public OdfPackage parsePackage(Path toParse) throws ParseException, FileNotFoundException {
         return this.packageParser.parsePackage(toParse);
     }
 
     @Override
-    public OdfPackage parsePackage(File toParse) throws IOException {
+    public OdfPackage parsePackage(File toParse) throws ParseException, FileNotFoundException {
         return this.packageParser.parsePackage(toParse);
     }
 
     @Override
-    public OdfPackage parsePackage(final InputStream toParse, final String name) throws IOException {
+    public OdfPackage parsePackage(final InputStream toParse, final String name) throws ParseException {
         return this.packageParser.parsePackage(toParse, name);
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractProfile.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractProfile.java
@@ -1,11 +1,11 @@
 package org.openpreservation.odf.validation.rules;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
@@ -46,7 +46,7 @@ abstract class AbstractProfile implements Profile {
     }
 
     @Override
-    public ProfileResult check(OdfXmlDocument document) throws IOException {
+    public ProfileResult check(OdfXmlDocument document) throws ParseException {
         MessageLog log = Messages.messageLogInstance();
         for (Rule rule : this.rules) {
             log.add(rule.check(document).getMessages());

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
@@ -1,6 +1,5 @@
 package org.openpreservation.odf.validation.rules;
 
-import java.io.IOException;
 import java.util.Objects;
 
 import org.openpreservation.messages.Message.Severity;
@@ -8,6 +7,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class DigitalSignaturesRule extends AbstractRule {
@@ -28,7 +28,7 @@ final class DigitalSignaturesRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (odfPackage.hasDsigEntries()) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRule.java
@@ -1,12 +1,11 @@
 package org.openpreservation.odf.validation.rules;
 
-import java.io.IOException;
 import java.util.Objects;
 
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
-import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public class EmbeddedObjectsRule extends AbstractRule {
@@ -28,13 +27,13 @@ public class EmbeddedObjectsRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) throws IOException {
+    public MessageLog check(final OdfXmlDocument document) throws ParseException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         return this.schematron.check(odfPackage);
     }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
@@ -8,6 +8,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.FileEntry;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class EncryptionRule extends AbstractRule {
@@ -28,7 +29,7 @@ final class EncryptionRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasManifest()) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
@@ -8,6 +8,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class ExtensionMimeTypeRule extends AbstractRule {
@@ -31,7 +32,7 @@ final class ExtensionMimeTypeRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasMimeEntry()

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/MacroRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/MacroRule.java
@@ -11,6 +11,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.FileEntry;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 import org.xml.sax.SAXException;
 
@@ -34,14 +35,19 @@ final class MacroRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) throws IOException {
+    public MessageLog check(final OdfXmlDocument document) throws ParseException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
-        MessageLog messageLog = checkOdfScriptXml(odfPackage);
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
+        MessageLog messageLog;
+        try {
+            messageLog = checkOdfScriptXml(odfPackage);
+        } catch (IOException e) {
+            throw new ParseException("IOException when checking for macros.", e);
+        }
         messageLog.add(schematron.check(odfPackage).getMessages());
         return messageLog;
     }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
@@ -8,6 +8,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class PackageMimeTypeRule extends AbstractRule {
@@ -29,7 +30,7 @@ final class PackageMimeTypeRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasMimeEntry()) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
@@ -1,11 +1,11 @@
 package org.openpreservation.odf.validation.rules;
 
-import java.io.IOException;
 import java.util.Set;
 
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.ValidationReport;
@@ -20,7 +20,7 @@ final class ProfileImpl extends AbstractProfile {
     }
  
     @Override
-    public ProfileResult check(final OdfPackage odfPackage) throws IOException {
+    public ProfileResult check(final OdfPackage odfPackage) throws ParseException {
         ValidationReport report = null;
         final MessageLog messages = Messages.messageLogInstance();
         for (final Rule rule : this.rules) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
@@ -14,6 +14,7 @@ import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.FileEntry;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import com.helger.schematron.pure.SchematronResourcePure;
@@ -37,13 +38,13 @@ final class SchematronRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) throws IOException {
+    public MessageLog check(final OdfXmlDocument document) throws ParseException {
         // TODO Auto-generated method stub
         throw new UnsupportedOperationException("Unimplemented method 'check'");
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         for (final FileEntry entry : odfPackage.getXmlEntries()) {
@@ -60,7 +61,7 @@ final class SchematronRule extends AbstractRule {
                                     result.getText()));
                 }
             } catch (final Exception e) {
-                throw new IOException(e);
+                throw new ParseException("Unexpected Exception caught when executing Schematron checks.", e);
             }
         }
         return messageLog;

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
@@ -8,6 +8,7 @@ import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class SubDocumentRule extends AbstractRule {
@@ -28,7 +29,7 @@ final class SubDocumentRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (odfPackage.hasManifest() && odfPackage.getManifest().getDocumentEntries().size() > 1) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
@@ -1,6 +1,6 @@
 package org.openpreservation.odf.validation.rules;
 
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.util.Objects;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -10,12 +10,14 @@ import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.ValidatingParser;
 import org.openpreservation.odf.validation.ValidationReport;
 import org.openpreservation.odf.validation.Validators;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 import org.openpreservation.odf.xml.Version;
 import org.xml.sax.SAXException;
+
 
 class ValidPackageRule extends AbstractRule {
     private static final String VER_MESS = "Package version: %s detected. ";
@@ -43,10 +45,14 @@ class ValidPackageRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws IOException {
+    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        this.validationReport = this.validatingParser.validatePackage(odfPackage);
+        try {
+            this.validationReport = this.validatingParser.validatePackage(odfPackage);
+        } catch (FileNotFoundException e) {
+            throw new ParseException("File not found exception when processing package.", e);
+        }
         if (!this.validationReport.isValid() || !odfPackage.getDetectedVersion().equals(Version.ODF_13)) {
             String message = "";
             if (!odfPackage.getDetectedVersion().equals(Version.ODF_13)) {

--- a/odf-core/src/test/java/org/openpreservation/odf/document/DocumentsTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/document/DocumentsTest.java
@@ -20,6 +20,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.DocumentType;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 import org.openpreservation.odf.xml.OdfXmlDocuments;
@@ -62,7 +63,7 @@ public class DocumentsTest {
 
     @Test
     public void testOpenDocInstantiationOfPackage()
-            throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+            throws IOException, ParseException, URISyntaxException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = Documents.openDocumentOf(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/document/OpenDocumentImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/document/OpenDocumentImplTest.java
@@ -16,6 +16,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.xml.sax.SAXException;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -55,7 +56,7 @@ public class OpenDocumentImplTest {
     }
 
     @Test
-    public void testGetDocumentPackage() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+    public void testGetDocumentPackage() throws IOException, ParseException, URISyntaxException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = OpenDocumentImpl.of(pkg);
@@ -70,7 +71,7 @@ public class OpenDocumentImplTest {
     }
 
     @Test
-    public void testGetFileTypePackage() throws IOException, ParserConfigurationException, SAXException, URISyntaxException {
+    public void testGetFileTypePackage() throws IOException, ParseException, URISyntaxException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = OpenDocumentImpl.of(pkg);
@@ -78,7 +79,7 @@ public class OpenDocumentImplTest {
     }
 
     @Test
-    public void testGetPackage() throws IOException, URISyntaxException {
+    public void testGetPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = OpenDocumentImpl.of(pkg);
@@ -86,7 +87,7 @@ public class OpenDocumentImplTest {
     }
 
     @Test
-    public void testGetSubDocuments() throws IOException, URISyntaxException {
+    public void testGetSubDocuments() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = OpenDocumentImpl.of(pkg);
@@ -102,7 +103,7 @@ public class OpenDocumentImplTest {
     }
 
     @Test
-    public void testIsPackagePackage() throws IOException, URISyntaxException {
+    public void testIsPackagePackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         OpenDocument openDoc = OpenDocumentImpl.of(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/pkg/OdfPackageDocumentTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/pkg/OdfPackageDocumentTest.java
@@ -8,17 +8,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.xml.sax.SAXException;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.DocumentType;
 import org.openpreservation.odf.xml.Version;
 
 public class OdfPackageDocumentTest {
     @Test
-    public void testParseDocument() throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+    public void testParseDocument() throws ParseException, URISyntaxException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         InputStream is = TestFiles.EMPTY_ODS.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.EMPTY_ODS.toString());
@@ -38,7 +36,7 @@ public class OdfPackageDocumentTest {
 
     @Test
     public void testParseSubDocument()
-            throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+            throws ParseException, URISyntaxException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         InputStream is = TestFiles.EMPTY_ODS.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.EMPTY_ODS.toString());
@@ -57,7 +55,7 @@ public class OdfPackageDocumentTest {
 
     @Test
     public void testParseStylesDocument()
-            throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+            throws URISyntaxException, ParseException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         InputStream is = TestFiles.STYLES_ONLY_DOC.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.STYLES_ONLY_DOC.toString());

--- a/odf-core/src/test/java/org/openpreservation/odf/pkg/OdfPackageTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/pkg/OdfPackageTest.java
@@ -19,6 +19,7 @@ import org.junit.Test;
 import org.openpreservation.format.zip.ZipEntry;
 import org.openpreservation.odf.fmt.Formats;
 import org.openpreservation.odf.fmt.TestFiles;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.Metadata;
 import org.openpreservation.odf.xml.OdfXmlDocuments;
 import org.xml.sax.SAXException;
@@ -42,21 +43,21 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testWellFormedZip() throws IOException, URISyntaxException {
+    public void testWellFormedZip() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertTrue("Package should be a well formed zip", pkg.isWellFormedZip());
     }
 
     @Test
-    public void testGetName() throws IOException, URISyntaxException {
+    public void testGetName() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertEquals("Package name should be passed String", new File(TestFiles.EMPTY_ODS.toURI()).getName(), pkg.getName());
     }
 
     @Test
-    public void testHasMimeEntry() throws IOException, URISyntaxException {
+    public void testHasMimeEntry() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertTrue("Package should have a mimetype entry", pkg.hasMimeEntry());
@@ -65,7 +66,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testGetFormat() throws IOException, URISyntaxException {
+    public void testGetFormat() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertEquals(Formats.ODS, pkg.getDetectedFormat());
@@ -74,7 +75,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testHasManifest() throws IOException, URISyntaxException {
+    public void testHasManifest() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertTrue(pkg.hasManifest());
@@ -83,7 +84,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testGetManifest() throws ParserConfigurationException, SAXException, IOException, URISyntaxException {
+    public void testGetManifest() throws ParserConfigurationException, SAXException, IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         Manifest manifest = pkg.getManifest();
@@ -94,7 +95,7 @@ public class OdfPackageTest {
 
     @Test
     public void testGetManifestNoMime()
-            throws ParserConfigurationException, SAXException, IOException, URISyntaxException {
+            throws ParserConfigurationException, SAXException, IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser
                 .parsePackage(new File(TestFiles.NO_MIME_ROOT_ODS.toURI()));
@@ -105,7 +106,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testGetMetadata() throws ParserConfigurationException, SAXException, IOException, URISyntaxException {
+    public void testGetMetadata() throws ParserConfigurationException, SAXException, IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         Metadata metadata = pkg.getDocument().getMetadata();
@@ -115,7 +116,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testIsMimeFirst() throws IOException, URISyntaxException {
+    public void testIsMimeFirst() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertTrue("MIME entry should be first", pkg.isMimeFirst());
@@ -126,7 +127,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testIsMimeCompressed() throws IOException, URISyntaxException {
+    public void testIsMimeCompressed() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         ZipEntry entry = pkg.getZipArchive().getZipEntry(OdfPackages.MIMETYPE);
@@ -143,7 +144,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testHasThumbnail() throws IOException, URISyntaxException {
+    public void testHasThumbnail() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertTrue("Package should have a thumbnail", pkg.hasThumbnail());
@@ -152,7 +153,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testXmlEntryPaths() throws IOException, URISyntaxException {
+    public void testXmlEntryPaths() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.DSIG_INVALID.toURI()));
         final List<String> entryPaths = Collections.unmodifiableList(pkg.getXmlEntryPaths());
@@ -167,7 +168,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testXmlParseResults() throws IOException, URISyntaxException {
+    public void testXmlParseResults() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         for (String entryPath: pkg.getXmlEntryPaths()) {
@@ -177,7 +178,7 @@ public class OdfPackageTest {
     }
 
     @Test
-    public void testgetEntryStream() throws IOException, URISyntaxException {
+    public void testgetEntryStream() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = PackageParserImpl.getInstance();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         for (FileEntry manifestEntry: pkg.getManifest().getEntries()) {

--- a/odf-core/src/test/java/org/openpreservation/odf/pkg/PackageParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/pkg/PackageParserTest.java
@@ -20,6 +20,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.odf.fmt.TestFiles;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.xml.Version;
 import org.xml.sax.SAXException;
 
@@ -97,7 +98,7 @@ public class PackageParserTest {
     }
 
     @Test
-    public void testParseNullStream() throws ParserConfigurationException, SAXException, IOException {
+    public void testParseNullStream() throws ParseException, SAXException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
@@ -114,7 +115,7 @@ public class PackageParserTest {
 
     @Test
     public void testParsePackagePath()
-            throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+            throws ParseException, URISyntaxException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         assertNotNull("Parsed package should not be null", pkg);
@@ -125,7 +126,7 @@ public class PackageParserTest {
 
     @Test
     public void testParsePackageFile()
-            throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+            throws ParseException, URISyntaxException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertNotNull("Parsed package should not be null", pkg);
@@ -136,7 +137,7 @@ public class PackageParserTest {
 
     @Test
     public void testParsePackageStream()
-            throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+            throws ParseException, URISyntaxException, IOException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.EMPTY_ODS.openStream(), TestFiles.EMPTY_ODS.toString());
         assertNotNull("Parsed package should not be null", pkg);
@@ -146,7 +147,7 @@ public class PackageParserTest {
     }
 
     @Test
-    public void testDsigParsing() throws ParserConfigurationException, SAXException, IOException {
+    public void testDsigParsing() throws IOException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.DSIG_INVALID.openStream(), TestFiles.DSIG_INVALID.toString());
         ParseResult result = pkg.getEntryXmlParseResult("META-INF/documentsignatures.xml");
@@ -155,7 +156,7 @@ public class PackageParserTest {
     }
 
     @Test
-    public void testManifestNotWF() throws IOException {
+    public void testManifestNotWF() throws IOException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_NOT_WF.openStream(),
                 TestFiles.MANIFEST_NOT_WF.toString());
@@ -165,7 +166,7 @@ public class PackageParserTest {
     }
 
     @Test
-    public void testVersionDetection() throws IOException {
+    public void testVersionDetection() throws IOException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.VER_1_3_ODS.openStream(),
                 TestFiles.VER_1_3_ODS.toString());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
@@ -19,6 +19,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.xml.sax.SAXException;
 
 public class ValidatingParserTest {
@@ -34,7 +35,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testParsePath() throws ParserConfigurationException, SAXException, URISyntaxException, IOException {
+    public void testParsePath() throws ParseException, URISyntaxException, IOException, ParserConfigurationException, SAXException {
         ValidatingParser parser = Validators.getValidatingParser();
         URL resourceUrl = TestFiles.EMPTY_ODS;
         Path path = Paths.get(resourceUrl.toURI());
@@ -56,7 +57,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testParseFile() throws ParserConfigurationException, SAXException, IOException, URISyntaxException {
+    public void testParseFile() throws ParseException, IOException, URISyntaxException, ParserConfigurationException, SAXException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
         assertNotNull("Parsed package should not be null", pkg);
@@ -87,7 +88,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testParseStream() throws ParserConfigurationException, SAXException, IOException {
+    public void testParseStream() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.EMPTY_ODS.openStream(), TestFiles.EMPTY_ODS.toString());
         assertNotNull("Parsed package should not be null", pkg);
@@ -96,7 +97,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testValidPackage() throws ParserConfigurationException, SAXException, IOException {
+    public void testValidPackage() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.EMPTY_ODS.openStream(), TestFiles.EMPTY_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -104,7 +105,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testInValidZip() throws ParserConfigurationException, SAXException, IOException {
+    public void testInValidZip() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.FAKEMIME_TEXT.openStream(), TestFiles.FAKEMIME_TEXT.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -113,7 +114,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testBadlyFormedPackage() throws ParserConfigurationException, SAXException, IOException {
+    public void testBadlyFormedPackage() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.BADLY_FORMED_PKG.openStream(), TestFiles.BADLY_FORMED_PKG.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -124,7 +125,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoManifest() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoManifest() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.NO_MANIFEST_ODS.openStream(), TestFiles.NO_MANIFEST_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -133,7 +134,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestRootNoMime() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestRootNoMime() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_ROOT_NO_MIME_ODS.openStream(), TestFiles.MANIFEST_ROOT_NO_MIME_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -142,7 +143,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestRootRandMimetype() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestRootRandMimetype() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_RAND_MIMETYPE_ODS.openStream(), TestFiles.MANIFEST_RAND_MIMETYPE_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -151,7 +152,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestRandRootMime() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestRandRootMime() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_RAND_ROOT_MIME_ODS.openStream(), TestFiles.MANIFEST_RAND_ROOT_MIME_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -160,7 +161,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestRootDiffMime() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestRootDiffMime() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_DIFF_MIME_ODS.openStream(), TestFiles.MANIFEST_DIFF_MIME_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -169,7 +170,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestEmptyRootMime() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestEmptyRootMime() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS.openStream(), TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -178,7 +179,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testManifestEntry() throws ParserConfigurationException, SAXException, IOException {
+    public void testManifestEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_ENTRY_ODS.openStream(), TestFiles.MANIFEST_ENTRY_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -187,7 +188,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMimetypeEntry() throws ParserConfigurationException, SAXException, IOException {
+    public void testMimetypeEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MIMETYPE_ENTRY_ODS.openStream(), TestFiles.MIMETYPE_ENTRY_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -196,7 +197,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMetainfEntry() throws ParserConfigurationException, SAXException, IOException {
+    public void testMetainfEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.METAINF_ENTRY_ODT.openStream(), TestFiles.METAINF_ENTRY_ODT.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -205,7 +206,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMissingManifestEntry() throws ParserConfigurationException, SAXException, IOException {
+    public void testMissingManifestEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_MISSING_ENTRY_ODS.openStream(), TestFiles.MANIFEST_MISSING_ENTRY_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -214,7 +215,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMissingXmlEntry() throws ParserConfigurationException, SAXException, IOException {
+    public void testMissingXmlEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS.openStream(), TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -223,7 +224,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMissingFile() throws ParserConfigurationException, SAXException, IOException {
+    public void testMissingFile() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MISSING_FILE_ODS.openStream(), TestFiles.MISSING_FILE_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -232,7 +233,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoMimeWithRoot() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoMimeWithRoot() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.NO_MIME_ROOT_ODS.openStream(), TestFiles.NO_MIME_ROOT_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -241,7 +242,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoRootMimeTyoe() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoRootMimeTyoe() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS.openStream(), TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -250,7 +251,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoMimeNoRoot() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoMimeNoRoot() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.NO_MIME_NO_ROOT_ODS.openStream(), TestFiles.NO_MIME_NO_ROOT_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -260,7 +261,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMimeLast() throws ParserConfigurationException, SAXException, IOException {
+    public void testMimeLast() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MIME_LAST_ODS.openStream(), TestFiles.MIME_LAST_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -269,7 +270,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMimeCompressed() throws ParserConfigurationException, SAXException, IOException {
+    public void testMimeCompressed() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MIME_COMPRESSED_ODS.openStream(), TestFiles.MIME_COMPRESSED_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -278,7 +279,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMimeCompressedLast() throws ParserConfigurationException, SAXException, IOException {
+    public void testMimeCompressedLast() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MIME_COMPRESSED_LAST_ODS.openStream(), TestFiles.MIME_COMPRESSED_LAST_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -288,7 +289,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testMimeExtra() throws ParserConfigurationException, SAXException, IOException {
+    public void testMimeExtra() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.MIME_EXTRA_ODS.openStream(), TestFiles.MIME_EXTRA_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -297,7 +298,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoThumbnail() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoThumbnail() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.NO_THUMBNAIL_ODS.openStream(), TestFiles.NO_THUMBNAIL_ODS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -306,7 +307,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoEmbeddedWord() throws ParserConfigurationException, SAXException, IOException {
+    public void testNoEmbeddedWord() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.EMBEDDED_WORD.openStream(), TestFiles.EMBEDDED_WORD.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -314,7 +315,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testPasswordEncrypted() throws ParserConfigurationException, SAXException, IOException {
+    public void testPasswordEncrypted() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pkg = parser.parsePackage(TestFiles.ENCRYPTED_PASSWORDS.openStream(), TestFiles.ENCRYPTED_PASSWORDS.toString());
         ValidationReport report = parser.validatePackage(pkg);
@@ -323,7 +324,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testDsigValid() throws ParserConfigurationException, SAXException, IOException {
+    public void testDsigValid() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         InputStream is = TestFiles.DSIG_VALID.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_VALID.toString());
@@ -332,7 +333,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testDsigInvalid() throws ParserConfigurationException, SAXException, IOException {
+    public void testDsigInvalid() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         InputStream is = TestFiles.DSIG_INVALID.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_INVALID.toString());
@@ -341,7 +342,7 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testDsigInvalidBadName() throws ParserConfigurationException, SAXException, IOException {
+    public void testDsigInvalidBadName() throws ParserConfigurationException, SAXException, IOException, ParseException {
         ValidatingParser parser = Validators.getValidatingParser();
         InputStream is = TestFiles.DSIG_BADNAME.openStream();
         OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_BADNAME.toString());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
@@ -16,6 +16,7 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.xml.sax.SAXException;
 
 public class ValidatorTest {
@@ -32,7 +33,8 @@ public class ValidatorTest {
     }
 
     @Test
-    public void validateNoSuchPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateNoSuchPath()
+            throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
         Validator validator = new Validator();
         Path noSuchFile = Paths.get("n0SuchDF1l3");
         assertThrows("FileNotFoundException expected",
@@ -47,21 +49,21 @@ public class ValidatorTest {
         Validator validator = new Validator();
         Path noSuchFile = Paths.get(".");
         assertThrows("IllegalArgumentException expected",
-        IllegalArgumentException.class,
+                IllegalArgumentException.class,
                 () -> {
                     validator.validate(noSuchFile);
                 });
     }
 
     @Test
-    public void validatePath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validatePath() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.EMPTY_ODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateNullFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateNullFile() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         File nullFile = null;
         assertThrows("NullPointerException expected",
@@ -72,53 +74,53 @@ public class ValidatorTest {
     }
 
     @Test
-    public void validateFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateFile() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.EMPTY_ODS.toURI()));
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateEmpty() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateEmpty() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.EMPTY.toURI()).toPath());
-        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertFalse("Package should NOT be valid, spreadsheets only.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
     }
 
     @Test
-    public void validateNoMimeNoRoot() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateNoMimeNoRoot() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateDocXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateDocXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.EMPTY_FODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateDocInvalidXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateDocInvalidXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath());
-        assertFalse("Document should NOT be valid." , report.isValid());
+        assertFalse("Document should NOT be valid.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
     }
 
     @Test
-    public void validateDocNotWellFormedXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateDocNotWellFormedXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath());
-        assertFalse("Document should NOT be valid." , report.isValid());
+        assertFalse("Document should NOT be valid.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
     }
 
     @Test
-    public void validateSpreadsheetNullPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetNullPath() throws ParseException, URISyntaxException {
         Validator validator = new Validator();
         Path nullPath = null;
         assertThrows("NullPointerException expected",
@@ -129,14 +131,14 @@ public class ValidatorTest {
     }
 
     @Test
-    public void validateSpreadsheetPath() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetPath() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_ODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateSpreadsheetNullFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetNullFile() throws ParserConfigurationException {
         Validator validator = new Validator();
         File nullFile = null;
         assertThrows("NullPointerException expected",
@@ -147,56 +149,57 @@ public class ValidatorTest {
     }
 
     @Test
-    public void validateSpreadsheetFile() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetFile() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_ODS.toURI()));
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateSingleFormatInvalid() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSingleFormatInvalid() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.DSIG_INVALID.toURI()).toPath());
-        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertFalse("Package should NOT be valid, spreadsheets only.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
     }
 
     @Test
-    public void validateSingleFormatEmpty() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSingleFormatEmpty() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY.toURI()).toPath());
-        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        assertFalse("Package should NOT be valid, spreadsheets only.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-6")).count());
     }
 
     @Test
-    public void validateSingleFormatNoMimeNoRoot() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSingleFormatNoMimeNoRoot() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
-        ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath());
-        assertFalse("Package should NOT be valid, spreadsheets only." , report.isValid());
+        ValidationReport report = validator
+                .validateSpreadsheet(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath());
+        assertFalse("Package should NOT be valid, spreadsheets only.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
     }
 
     @Test
-    public void validateSingleFormatDocXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSingleFormatDocXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.EMPTY_FODS.toURI()).toPath());
-        assertTrue("Package should be valid." , report.isValid());
+        assertTrue("Package should be valid.", report.isValid());
     }
 
     @Test
-    public void validateSpreadsheetDocInvalidXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetDocInvalidXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath());
-        assertFalse("Document should NOT be valid." , report.isValid());
+        assertFalse("Document should NOT be valid.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
     }
 
     @Test
-    public void validateSpreadsheetDocNotWellFormedXml() throws ParserConfigurationException, IOException, SAXException, URISyntaxException {
+    public void validateSpreadsheetDocNotWellFormedXml() throws ParseException, IOException, URISyntaxException {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSpreadsheet(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath());
-        assertFalse("Document should NOT be valid." , report.isValid());
+        assertFalse("Document should NOT be valid.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
@@ -17,6 +17,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -56,7 +57,7 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -64,7 +65,7 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException {
+    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -72,7 +73,7 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException {
+    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -80,7 +81,7 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException {
+    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -88,7 +89,7 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckValidDsigPackage() throws IOException, URISyntaxException {
+    public void testCheckValidDsigPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.DSIG_VALID.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
@@ -20,6 +20,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -80,7 +81,7 @@ public class EmbeddedObjectsRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -88,7 +89,7 @@ public class EmbeddedObjectsRuleTest {
     }
 
     @Test
-    public void testCheckEmbeddedPackage() throws IOException, URISyntaxException {
+    public void testCheckEmbeddedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.OLE_EMBEDDED_PACKAGE.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EncryptionRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EncryptionRuleTest.java
@@ -17,6 +17,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -55,7 +56,7 @@ public class EncryptionRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -63,7 +64,7 @@ public class EncryptionRuleTest {
     }
 
     @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException {
+    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -71,7 +72,7 @@ public class EncryptionRuleTest {
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException {
+    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -79,7 +80,7 @@ public class EncryptionRuleTest {
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException {
+    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -87,7 +88,7 @@ public class EncryptionRuleTest {
     }
 
     @Test
-    public void testCheckValidEncryptedPackage() throws IOException, URISyntaxException {
+    public void testCheckValidEncryptedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.ENCRYPTED_PASSWORDS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
@@ -18,6 +18,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -56,7 +57,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -64,7 +65,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException {
+    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -73,7 +74,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException {
+    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -82,7 +83,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException {
+    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -90,7 +91,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNotOdsPackage() throws IOException, URISyntaxException {
+    public void testCheckNotOdsPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.DSIG_INVALID.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -99,7 +100,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckBadExtPackage() throws IOException, URISyntaxException {
+    public void testCheckBadExtPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_EXT.toURI()).getAbsolutePath()));
         assertEquals("Package should have spreadsheet MIME value", Formats.ODS.mime, pkg.getMimeType());
@@ -109,7 +110,7 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckBadMimePackage() throws IOException, URISyntaxException {
+    public void testCheckBadMimePackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_MIME.toURI()).getAbsolutePath()));
         assertEquals("Package should have template MIME value", Formats.OTS.mime, pkg.getMimeType());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
@@ -17,6 +17,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -55,7 +56,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -63,7 +64,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException {
+    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -72,7 +73,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException {
+    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -81,7 +82,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException {
+    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -89,7 +90,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNoMimePackage() throws IOException, URISyntaxException {
+    public void testCheckNoMimePackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.NO_MIME_ROOT_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -98,7 +99,7 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNoMimeNoRootPackage() throws IOException, URISyntaxException {
+    public void testCheckNoMimeNoRootPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
@@ -1,6 +1,5 @@
 package org.openpreservation.odf.validation.rules;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -14,12 +13,13 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
 
 public class ProfileImplTest {
     @Test
-    public void testCheck() throws IOException, URISyntaxException {
+    public void testCheck() throws IOException, URISyntaxException, ParseException {
         Profile profile = Rules.getDnaProfile();
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/SubDocumentRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/SubDocumentRuleTest.java
@@ -17,6 +17,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
@@ -56,7 +57,7 @@ public class SubDocumentRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException {
+    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -65,7 +66,7 @@ public class SubDocumentRuleTest {
     }
 
     @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException {
+    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -73,7 +74,7 @@ public class SubDocumentRuleTest {
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException {
+    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -81,7 +82,7 @@ public class SubDocumentRuleTest {
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException {
+    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -90,7 +91,7 @@ public class SubDocumentRuleTest {
     }
 
     @Test
-    public void testCheckValidDsigPackage() throws IOException, URISyntaxException {
+    public void testCheckValidDsigPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.DSIG_VALID.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
@@ -19,6 +19,7 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 import org.xml.sax.SAXException;
@@ -60,7 +61,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testCheckValidPackage()
-            throws IOException, URISyntaxException, ParserConfigurationException, SAXException {
+            throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -69,7 +70,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testCheckNotZipPackage()
-            throws IOException, URISyntaxException, ParserConfigurationException, SAXException {
+            throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -79,7 +80,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testCheckNotWellFormedPackage()
-            throws IOException, URISyntaxException, ParserConfigurationException, SAXException {
+            throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
@@ -89,7 +90,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testCheckInvalidPackage()
-            throws IOException, URISyntaxException, ParserConfigurationException, SAXException {
+            throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);


### PR DESCRIPTION
- unexpected exceptionswrapped as `ParseException` to allow uniform handling;
  - added to validation and parsing interfaces;
  - `ParseException`s are logged as errors, other files are still processed;
- `PackageParser` now checks for unsuppported zip features;
- other code cleanup to catch exceptions early and pass `ParseException`s up the stack; and
- changed test cases to match new method sigs.