### PR TITLE
FIX: CLI version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ODF Validator
 
-Latest version is 0.13.1.
+Latest version is 0.14.0-SNAPSHOT.
 
 ## About
 

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -44,7 +44,7 @@ To include the core validation library in your project, add the following depend
 <dependency>
     <groupId>org.openpreservation.odf</groupId>
     <artifactId>odf-core</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/odf-apps/pom.xml
+++ b/odf-apps/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.odf</groupId>
     <artifactId>odf-validator</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -20,6 +20,12 @@
   </properties>
 
   <build>
+   <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -82,7 +88,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.23.0</version>
+      <version>1.27.1</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/junit/junit -->
     <dependency>

--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/BuildVersionProvider.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/BuildVersionProvider.java
@@ -1,0 +1,50 @@
+package org.openpreservation.odf.apps;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Properties;
+import java.util.logging.Level;
+
+import picocli.CommandLine.IVersionProvider;
+
+public class BuildVersionProvider implements IVersionProvider {
+    private static final String RAW_DATE_FORMAT = "${maven.build.timestamp.format}";
+
+    @Override
+    public String[] getVersion() throws Exception {
+        Properties props = fromResource("org/openpreservation/odf/apps/build.properties");
+        String name = props.getProperty("project.name"); //$NON-NLS-1$
+        String version = props.getProperty("release.version"); //$NON-NLS-1$
+        String dateFormat = props.getProperty("date.format"); //$NON-NLS-1$
+        Date date = new Date();
+        if (!dateFormat.equals(RAW_DATE_FORMAT)) {
+            SimpleDateFormat formatter = new SimpleDateFormat(dateFormat);
+            try {
+                date = formatter.parse(props.getProperty("release.date")); //$NON-NLS-1$
+            } catch (ParseException e) {
+                /**
+                 * Safe to ignore this exception as release simply set to new
+                 * date.
+                 */
+            }
+        }
+        return new String[] { name + " v" + version, //$NON-NLS-1$
+                "Built: " + new SimpleDateFormat("yyyy-MM-dd").format(date) }; //$NON-NLS-1$
+    }
+
+    private static Properties fromResource(final String resourceName) {
+        try (InputStream is = BuildVersionProvider.class.getClassLoader().getResourceAsStream(resourceName)) {
+            Properties props = new Properties();
+            if (is != null) {
+                props.load(is);
+            }
+            return props;
+        } catch (IOException excep) {
+            throw new IllegalStateException("Couldn't load resource:" + resourceName, excep); //$NON-NLS-1$
+        }
+    }
+
+}

--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
@@ -28,7 +28,7 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
-@Command(name = "odf-validator", mixinStandardHelpOptions = true, version = "odf-validator 0.1", description = "Validates Open Document Format spreadsheets.")
+@Command(name = "odf-validator", mixinStandardHelpOptions = true, versionProvider = BuildVersionProvider.class, description = "Validates Open Document Format spreadsheets.")
 class CliValidator implements Callable<Integer> {
     private static final MessageFactory FACTORY = Messages
             .getInstance("org.openpreservation.odf.apps.messages.Messages");

--- a/odf-apps/src/main/resources/org/openpreservation/odf/apps/build.properties
+++ b/odf-apps/src/main/resources/org/openpreservation/odf/apps/build.properties
@@ -1,0 +1,4 @@
+project.name=${project.name}
+release.version=${project.version}
+release.date=${odfapps.timestamp}
+date.format=${maven.build.timestamp.format}

--- a/odf-core/pom.xml
+++ b/odf-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.odf</groupId>
     <artifactId>odf-validator</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odf-reporting/pom.xml
+++ b/odf-reporting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.openpreservation.odf</groupId>
     <artifactId>odf-validator</artifactId>
-    <version>0.13.1</version>
+    <version>0.14.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/odf-validator
+++ b/odf-validator
@@ -78,5 +78,5 @@ fi
 
 exec "$JAVACMD" -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions \
   -Dapp.name="ODF Validator" \
-  -jar odf-apps/target/odf-apps-0.13.1-jar-with-dependencies.jar \
+  -jar odf-apps/target/odf-apps-0.14.0-SNAPSHOT-jar-with-dependencies.jar \
   "$@"

--- a/odf-validator.bat
+++ b/odf-validator.bat
@@ -85,7 +85,7 @@ if NOT "%CLASSPATH_PREFIX%" == "" set CLASSPATH=%CLASSPATH_PREFIX%;%CLASSPATH%
 @REM Reaching here means variables are defined and arguments have been captured
 :endInit
 
-"%JAVACMD%" -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions -Dapp.name="ODF Validator" -jar .\odf-apps\target\odf-apps-0.13.1-jar-with-dependencies.jar %CMD_LINE_ARGS%
+"%JAVACMD%" -Dfile.encoding=UTF8 -XX:+IgnoreUnrecognizedVMOptions -Dapp.name="ODF Validator" -jar .\odf-apps\target\odf-apps-0.14.0-SNAPSHOT-jar-with-dependencies.jar %CMD_LINE_ARGS%
 if %ERRORLEVEL% NEQ 0 goto error
 goto end
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.openpreservation.odf</groupId>
   <artifactId>odf-validator</artifactId>
-  <version>0.13.1</version>
+  <version>0.14.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
- replaced hard coded version in `CliValidator`:
  - now uses `BuildVersionProvider` which implements `IVersionProvider`; and
  - reads release details from a java properties resource file `odf-apps/src/main/resources/org/openpreservation/odf/apps/build.properties`;
- updated version to `0.14.0-SNAPSHOT` for development; and
- checked in templated changes to batch files and documentation.