### PR TITLE
FIX: Pre-requisite handling

### DIFF
--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/BuildVersionProvider.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/BuildVersionProvider.java
@@ -6,7 +6,6 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Properties;
-import java.util.logging.Level;
 
 import picocli.CommandLine.IVersionProvider;
 

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
@@ -11,12 +11,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.validation.Schema;
 
-import org.openpreservation.format.xml.Namespace;
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.format.xml.ValidationResult;
 import org.openpreservation.format.xml.XmlValidator;
@@ -124,8 +122,9 @@ final class ValidatingParserImpl implements ValidatingParser {
         List<Message> messageList = new ArrayList<>();
         OdfNamespaces ns = OdfNamespaces.fromId(parseResult.getRootNamespace().getId());
         if (OdfXmlDocuments.odfXmlDocumentOf(parseResult).isExtended()) {
-            messageList.add(FACTORY.getError("DOC-8", Utils.collectNsPrefixes(OdfXmlDocuments.odfXmlDocumentOf(parseResult)
-                    .getForeignNamespaces())));
+            messageList
+                    .add(FACTORY.getError("DOC-8", Utils.collectNsPrefixes(OdfXmlDocuments.odfXmlDocumentOf(parseResult)
+                            .getForeignNamespaces())));
             return messageList;
         }
         Schema schema = (ns == null) ? null

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -6,12 +6,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.validation.Schema;
 
-import org.openpreservation.format.xml.Namespace;
 import org.openpreservation.format.xml.ParseResult;
 import org.openpreservation.format.xml.XmlParser;
 import org.openpreservation.format.xml.XmlValidator;

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
@@ -14,7 +14,7 @@ final class EncryptionRule extends AbstractRule {
 
     static final EncryptionRule getInstance(final Severity severity) {
         return new EncryptionRule("POL_1", "Encryption",
-                "The package MUST NOT contain any encrypted entries.", severity, true);
+                "The package MUST NOT contain any encrypted entries.", severity, false);
     }
 
     private EncryptionRule(final String id, final String name, final String description, final Severity severity,

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
@@ -27,7 +27,7 @@ class ValidPackageRule extends AbstractRule {
             throws ParserConfigurationException, SAXException {
         return new ValidPackageRule("POL_2", "Standard Compliance",
                 "The file MUST comply with the standard \"OASIS Open Document Format for Office Applications (OpenDocument) v1.3\".",
-                severity, true);
+                severity, false);
     }
 
     private final ValidatingParser validatingParser = Validators.getValidatingParser();

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
@@ -1,6 +1,5 @@
 package org.openpreservation.odf.validation.rules;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
- `POL-1` and `POL-2` are no longer pre-requisite rules, this means other policy rules will still run if these fail;
- cleaned up a bug in pre-requisite handling where Validation reports weren't generated;
- refactored the execution of Validation rules; and
- removed a few unused imports.

Closes #162 