### PR TITLE
REFACT: Tidied validator/profile calls

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
@@ -8,9 +8,16 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Profile {
     public String getId();
+
     public String getName();
+
     public String getDescription();
+
     public ProfileResult check(final OdfXmlDocument document) throws ParseException;
+
+    public ProfileResult check(final ValidationReport report) throws ParseException;
+
     public ProfileResult check(final OdfPackage odfPackage) throws ParseException;
+
     public Set<Rule> getRules();
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResult.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResult.java
@@ -4,7 +4,12 @@ import org.openpreservation.messages.MessageLog;
 
 public interface ProfileResult {
     public String getId();
+
+    public String getName();
+
     public ValidationReport getValidationReport();
-    public MessageLog getProfileMessages();
+
+    public MessageLog getMessageLog();
+
     public boolean isValid();
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
@@ -8,10 +8,18 @@ import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Rule {
     public String getId();
+
     public String getName();
+
     public String getDescription();
+
     public Severity getSeverity();
+
     public boolean isPrerequisite();
+
     public MessageLog check(final OdfXmlDocument document) throws ParseException;
+
     public MessageLog check(final OdfPackage odfPackage) throws ParseException;
+
+    public MessageLog check(final ValidationReport report) throws ParseException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
@@ -11,7 +11,7 @@ import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.document.OpenDocument;
 
 public final class ValidationReport {
-    final String name;
+    public final String name;
     public final OpenDocument document;
     public final MessageLog documentMessages;
 
@@ -33,6 +33,7 @@ public final class ValidationReport {
     static final ValidationReport of(final String name) {
         return new ValidationReport(name);
     }
+
     static final ValidationReport of(final String name, final OpenDocument document) {
         return new ValidationReport(name, document);
     }
@@ -41,7 +42,8 @@ public final class ValidationReport {
         return new ValidationReport(name, null, documentMessages);
     }
 
-    static final ValidationReport of(final String name, final OpenDocument document, final MessageLog documentMessages) {
+    static final ValidationReport of(final String name, final OpenDocument document,
+            final MessageLog documentMessages) {
         return new ValidationReport(name, document, documentMessages);
     }
 
@@ -69,6 +71,7 @@ public final class ValidationReport {
     public List<Message> getErrors() {
         return documentMessages.getErrors().values().stream().flatMap(List::stream).collect(Collectors.toList());
     }
+
     public List<Message> getMessages() {
         return documentMessages.getMessages().values().stream().flatMap(List::stream).collect(Collectors.toList());
     }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
@@ -3,7 +3,10 @@ package org.openpreservation.odf.validation.rules;
 import java.util.Objects;
 
 import org.openpreservation.messages.Message.Severity;
+import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
+import org.openpreservation.odf.validation.ValidationReport;
 
 abstract class AbstractRule implements Rule {
     final String id;
@@ -45,6 +48,11 @@ abstract class AbstractRule implements Rule {
     @Override
     public boolean isPrerequisite() {
         return this.isPrerequisite.booleanValue();
+    }
+
+    @Override
+    public MessageLog check(ValidationReport report) throws ParseException {
+        return report.document.isPackage() ? check(report.document.getPackage()) : check(report.document.getDocument().getXmlDocument());
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
@@ -8,6 +8,7 @@ import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
+import org.openpreservation.odf.validation.ValidationReport;
 import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class DigitalSignaturesRule extends AbstractRule {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
@@ -22,14 +22,15 @@ import org.openpreservation.odf.validation.Validators;
 import org.xml.sax.SAXException;
 
 final class ProfileImpl extends AbstractProfile {
-    static final ProfileImpl of(final String id, final String name, final String description, final Set<Rule> rules) throws ParserConfigurationException, SAXException {
+    private final ValidatingParser validatingParser = Validators.getValidatingParser();
+
+    static final ProfileImpl of(final String id, final String name, final String description, final Set<Rule> rules)
+            throws ParserConfigurationException, SAXException {
         return new ProfileImpl(id, name, description, rules);
     }
 
-    private final ValidatingParser validatingParser = Validators.getValidatingParser();
-
-
-    private ProfileImpl(final String id, final String name, final String description, final Set<Rule> rules) throws ParserConfigurationException, SAXException {
+    private ProfileImpl(final String id, final String name, final String description, final Set<Rule> rules)
+            throws ParserConfigurationException, SAXException {
         super(id, name, description, rules);
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
@@ -1,10 +1,13 @@
 package org.openpreservation.odf.validation.rules;
 
+import java.io.FileNotFoundException;
 import java.util.Collection;
 import java.util.Set;
 import java.util.Map;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import javax.xml.parsers.ParserConfigurationException;
 
 import org.openpreservation.messages.Message;
 import org.openpreservation.messages.MessageLog;
@@ -13,29 +16,42 @@ import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
+import org.openpreservation.odf.validation.ValidatingParser;
 import org.openpreservation.odf.validation.ValidationReport;
+import org.openpreservation.odf.validation.Validators;
+import org.xml.sax.SAXException;
 
 final class ProfileImpl extends AbstractProfile {
-    private ValidationReport report = null;
-
-    static final ProfileImpl of(final String id, final String name, final String description, final Set<Rule> rules) {
+    static final ProfileImpl of(final String id, final String name, final String description, final Set<Rule> rules) throws ParserConfigurationException, SAXException {
         return new ProfileImpl(id, name, description, rules);
     }
 
-    private ProfileImpl(final String id, final String name, final String description, final Set<Rule> rules) {
+    private final ValidatingParser validatingParser = Validators.getValidatingParser();
+
+
+    private ProfileImpl(final String id, final String name, final String description, final Set<Rule> rules) throws ParserConfigurationException, SAXException {
         super(id, name, description, rules);
     }
 
     @Override
     public ProfileResult check(final OdfPackage odfPackage) throws ParseException {
+        try {
+            return check(this.validatingParser.validatePackage(odfPackage));
+        } catch (FileNotFoundException e) {
+            throw new ParseException("File not found exception when processing package.", e);
+        }
+    }
+
+    @Override
+    public ProfileResult check(final ValidationReport report) throws ParseException {
         final MessageLog messages = Messages.messageLogInstance();
-        messages.add(getRulesetMessages(odfPackage,
+        messages.add(getRulesetMessages(report.document.getPackage(),
                 this.rules.stream().filter(Rule::isPrerequisite).collect(Collectors.toList())));
         if (!messages.hasErrors()) {
-            messages.add(getRulesetMessages(odfPackage,
+            messages.add(getRulesetMessages(report.document.getPackage(),
                     this.rules.stream().filter(rule -> !rule.isPrerequisite()).collect(Collectors.toList())));
         }
-        return ProfileResultImpl.of(odfPackage.getName(), report, messages);
+        return ProfileResultImpl.of(report.document.getPackage().getName(), this.name, report, messages);
     }
 
     private final Map<String, List<Message>> getRulesetMessages(final OdfPackage odfPackage,
@@ -43,9 +59,6 @@ final class ProfileImpl extends AbstractProfile {
         final MessageLog messages = Messages.messageLogInstance();
         for (final Rule rule : rules) {
             final MessageLog ruleMessages = rule.check(odfPackage);
-            if (rule instanceof ValidPackageRule) {
-                report = ((ValidPackageRule) rule).getValidationReport();
-            }
             messages.add(ruleMessages.getMessages());
         }
         return messages.getMessages();

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileResultImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileResultImpl.java
@@ -6,14 +6,16 @@ import org.openpreservation.odf.validation.ValidationReport;
 
 final class ProfileResultImpl implements ProfileResult {
     private final String id;
+    private final String name;
     private final ValidationReport validationReport;
-    private final MessageLog profileMessages;
+    private final MessageLog messageLog;
 
-    private ProfileResultImpl(final String id, final ValidationReport validationReport, final MessageLog profileMessages) {
+    private ProfileResultImpl(final String id, final String name, final ValidationReport validationReport, final MessageLog messageLog) {
         super();
         this.id = id;
+        this.name = name;
         this.validationReport = validationReport;
-        this.profileMessages = profileMessages;
+        this.messageLog = messageLog;
     }
 
     @Override
@@ -22,21 +24,26 @@ final class ProfileResultImpl implements ProfileResult {
     }
 
     @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
     public ValidationReport getValidationReport() {
         return this.validationReport;
     }
 
     @Override
-    public MessageLog getProfileMessages() {
-        return this.profileMessages;
+    public MessageLog getMessageLog() {
+        return this.messageLog;
     }
 
     @Override
     public boolean isValid() {
-        return !this.getProfileMessages().hasErrors();
+        return !this.getMessageLog().hasErrors();
     }
 
-    static final ProfileResultImpl of(final String id, final ValidationReport validationReport, final MessageLog profileMessages) {
-        return new ProfileResultImpl(id, validationReport, profileMessages);
+    static final ProfileResultImpl of(final String id, final String name, final ValidationReport validationReport, final MessageLog messageLog) {
+        return new ProfileResultImpl(id, name, validationReport, messageLog);
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
@@ -66,7 +66,7 @@ public class Rules {
         return SubDocumentRule.getInstance(Severity.WARNING);
     }
 
-    public static final Profile getDnaProfile() {
+    public static final Profile getDnaProfile() throws ParserConfigurationException, SAXException {
         return ProfileImpl.of("DNA", "DNA ODF Spreadsheets Preservation Specification",
                 "Extended validation for OpenDocument spreadsheets.", DNA_RULES);
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
@@ -16,10 +18,11 @@ import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
+import org.xml.sax.SAXException;
 
 public class ProfileImplTest {
     @Test
-    public void testCheck() throws IOException, URISyntaxException, ParseException {
+    public void testCheck() throws IOException, URISyntaxException, ParseException, ParserConfigurationException, SAXException {
         Profile profile = Rules.getDnaProfile();
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
@@ -30,7 +33,7 @@ public class ProfileImplTest {
     }
 
     @Test
-    public void testOf() {
+    public void testOf() throws ParserConfigurationException, SAXException {
         Profile profile = Rules.getDnaProfile();
         assertNotNull(profile);
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
@@ -31,7 +31,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testEqualsContract() {
-        EqualsVerifier.forClass(ValidPackageRule.class).withIgnoredFields("validatingParser", "validationReport").verify();
+        EqualsVerifier.forClass(ValidPackageRule.class).withIgnoredFields("validatingParser").verify();
     }
 
     @Test
@@ -75,7 +75,8 @@ public class ValidPackageRuleTest {
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
         assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream().filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
+        assertEquals(1, results.getMessages().values().stream()
+                .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 
     @Test
@@ -85,7 +86,8 @@ public class ValidPackageRuleTest {
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
         assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream().filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
+        assertEquals(1, results.getMessages().values().stream()
+                .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 
     @Test
@@ -95,6 +97,7 @@ public class ValidPackageRuleTest {
         OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
         MessageLog results = rule.check(pkg);
         assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream().filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
+        assertEquals(1, results.getMessages().values().stream()
+                .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 }


### PR DESCRIPTION
- profile is now invoked after validation rather than as a branch in CLI;
- added profiling via `ValidationReport` as half-way house before interface refactor;
- added Rule checking via `ValidationReport` and provided a simple method in `AbstractProfile` that calls existing `validate` method;
- improved some variable and method names;and
- made some CLI methods static.