### PR TITLE
FIX: Policy crash when package has no manifest

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -218,8 +218,10 @@ final class OdfPackageImpl implements OdfPackage {
     @Override
     public Set<FileEntry> getXmlEntries() {
         Set<FileEntry> entries = new HashSet<>();
-        for (FileEntry entry : this.manifest.getEntriesByMediaType("text/xml")) {
-            entries.add(entry);
+        if (this.manifest != null) {
+            for (FileEntry entry : this.manifest.getEntriesByMediaType("text/xml")) {
+                entries.add(entry);
+            }
         }
         return entries;
     }


### PR DESCRIPTION
- added check for null manifest when attempting to list package XML files.

Closes #193