### PR TITLE
FIX: Don't parse check missing entries

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -195,9 +195,12 @@ final class OdfPackageImpl implements OdfPackage {
         }
         Path parent = filePath.getParent();
         OdfPackageDocument doc = this.documentMap.get((parent == null) ? "/" : parent.toString());
-        return (doc == null) ? null
-                : doc.getXmlDocument(filePath.getFileName().toString())
-                        .getParseResult();
+        if (doc == null) {
+            return null;
+        }
+        OdfXmlDocument xmlDoc = doc.getXmlDocument(filePath.getFileName().toString());
+        return (xmlDoc == null) ? null
+                : xmlDoc.getParseResult();
     }
 
     @Override


### PR DESCRIPTION
- check that an XML document in the manifest exists before grabbing the parse entry.