### PR TITLE
FEAT: Flat file policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ODF Validator
 
 Latest version is 0.16.2-SNAPSHOT.
-=======
 
 ## About
 

--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
@@ -81,7 +81,7 @@ class CliValidator implements Callable<Integer> {
     private ProfileResult profileReport(final ValidationReport toProfile, final Path path) {
         try {
             final Profile dnaProfile = Rules.getDnaProfile();
-            return dnaProfile.check(toProfile);
+            return dnaProfile.check(toProfile.document);
         } catch (IllegalArgumentException e) {
             this.logMessage(path, Messages.getMessageInstance("APP-2", Severity.ERROR, e.getMessage()));
         } catch (ParseException | ParserConfigurationException | SAXException e) {

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchive.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchive.java
@@ -1,11 +1,19 @@
 package org.openpreservation.format.zip;
 
+import java.nio.file.Path;
 import java.util.List;
 
 /**
  * An interface for accessing the contents of a Zip archive.
  */
 public interface ZipArchive {
+    /**
+     * Get the path to the archive
+     *
+     * @return the <code>Path</code> to the archive
+     */
+    public Path getPath();
+
     /**
      * Returns the first physical {@link ZipEntry} in the archive.
      *

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveCacheImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveCacheImpl.java
@@ -2,6 +2,7 @@ package org.openpreservation.format.zip;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -49,5 +50,10 @@ final class ZipArchiveCacheImpl implements ZipArchiveCache {
     @Override
     public ZipEntry getFirstEntry() {
         return this.archive.getFirstEntry();
+    }
+
+    @Override
+    public Path getPath() {
+        return this.archive.getPath();
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipArchiveImpl.java
@@ -1,5 +1,6 @@
 package org.openpreservation.format.zip;
 
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -7,18 +8,26 @@ import java.util.Objects;
 import org.openpreservation.utils.Checks;
 
 final class ZipArchiveImpl implements ZipArchive {
-    static final ZipArchiveImpl from(final List<ZipEntry> entries) {
+    static final ZipArchiveImpl from(final Path path, final List<ZipEntry> entries) {
+        Objects.requireNonNull(path, String.format(Checks.NOT_NULL, "Path", "path"));
         Objects.requireNonNull(entries, String.format(Checks.NOT_NULL, "List<ZipEntry>", "entries"));
         if (entries.contains(null)) {
             throw new IllegalArgumentException("List<ZipEntry> entries cannot contain null entries");
         }
-        return new ZipArchiveImpl(entries);
+        return new ZipArchiveImpl(path, entries);
     }
 
+    private final Path path;
     private final List<ZipEntry> entries;
 
-    private ZipArchiveImpl(final List<ZipEntry> entries) {
+    private ZipArchiveImpl(final Path path, final List<ZipEntry> entries) {
+        this.path = path;
         this.entries = Collections.unmodifiableList(entries);
+    }
+
+    @Override
+    public Path getPath() {
+        return this.path;
     }
 
     @Override
@@ -51,6 +60,7 @@ final class ZipArchiveImpl implements ZipArchive {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
+        result = prime * result + ((path == null) ? 0 : path.hashCode());
         result = prime * result + ((entries == null) ? 0 : entries.hashCode());
         return result;
     }
@@ -68,6 +78,11 @@ final class ZipArchiveImpl implements ZipArchive {
             if (other.entries != null)
                 return false;
         } else if (!entries.equals(other.entries))
+            return false;
+        if (path == null) {
+            if (other.path != null)
+                return false;
+        } else if (!path.equals(other.path))
             return false;
         return true;
     }

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipFileProcessor.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipFileProcessor.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.compress.archivers.zip.ZipFile.Builder;
 import org.openpreservation.utils.Checks;
 
 /**
@@ -50,7 +51,7 @@ public final class ZipFileProcessor implements ZipArchiveCache {
 
     private final Map<String, ZipArchiveEntry> cache(final Path path) throws IOException {
         Map<String, ZipArchiveEntry> result = new HashMap<>();
-        try (ZipFile zipFile = new ZipFile(path)) {
+        try (ZipFile zipFile = new Builder().setSeekableByteChannel(Files.newByteChannel(path)).get()) {
             Enumeration<ZipArchiveEntry> entries = zipFile.getEntriesInPhysicalOrder();
             while (entries.hasMoreElements()) {
                 ZipArchiveEntry entry = entries.nextElement();
@@ -61,6 +62,11 @@ public final class ZipFileProcessor implements ZipArchiveCache {
             }
         }
         return result;
+    }
+
+    @Override
+    public Path getPath() {
+        return this.path;
     }
 
     @Override
@@ -108,7 +114,8 @@ public final class ZipFileProcessor implements ZipArchiveCache {
             return null;
         }
         if (!this.byteCache.containsKey(entryName)) {
-            try (ZipFile zipFile = new ZipFile(this.path)) {
+            try (ZipFile zipFile = new ZipFile.Builder().setSeekableByteChannel(Files.newByteChannel(this.path))
+                    .get()) {
                 ZipArchiveEntry entry = zipFile.getEntry(entryName);
                 if (entry == null) {
                     return null;

--- a/odf-core/src/main/java/org/openpreservation/format/zip/ZipProcessor.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/ZipProcessor.java
@@ -2,6 +2,7 @@ package org.openpreservation.format.zip;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Path;
 
 /**
  * Interface for a processor that processes an {@link InputStream} and a factory

--- a/odf-core/src/main/java/org/openpreservation/format/zip/Zips.java
+++ b/odf-core/src/main/java/org/openpreservation/format/zip/Zips.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -73,7 +74,7 @@ public final class Zips {
                     processor.process(entry, zis);
                 }
             }
-            return ZipArchiveImpl.from(entries);
+            return ZipArchiveImpl.from(Paths.get(""),  entries);
         }));
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/document/Documents.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/document/Documents.java
@@ -1,8 +1,11 @@
 package org.openpreservation.odf.document;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 import org.openpreservation.format.xml.ParseResult;
+import org.openpreservation.format.zip.ZipArchive;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.xml.Metadata;
 import org.openpreservation.odf.xml.OdfXmlDocument;
@@ -13,14 +16,15 @@ public class Documents {
         throw new AssertionError("Utility class 'Documents' should not be instantiated");
     }
 
-    public static final OpenDocument openDocumentOf(OdfDocument document) {
+    public static final OpenDocument openDocumentOf(final Path path, final OdfDocument document) {
         Objects.requireNonNull(document, "OdfDocument parameter document cannot be null");
-        return OpenDocumentImpl.of(document);
+        return OpenDocumentImpl.of(path, document);
     }
 
-    public static final OpenDocument openDocumentOf(OdfPackage pkg) {
+    public static final OpenDocument openDocumentOf(final Path path, final OdfPackage pkg) {
+        Objects.requireNonNull(path, "Path path document cannot be null");
         Objects.requireNonNull(pkg, "OdfPackage pkg document cannot be null");
-        return OpenDocumentImpl.of(pkg);
+        return OpenDocumentImpl.of(path, pkg);
     }
 
     public static final OdfDocument odfDocumentOf(final OdfXmlDocument xmlDocument, final Metadata metadata) {

--- a/odf-core/src/main/java/org/openpreservation/odf/document/OpenDocument.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/document/OpenDocument.java
@@ -1,5 +1,6 @@
 package org.openpreservation.odf.document;
 
+import java.nio.file.Path;
 import java.util.Collection;
 
 import org.openpreservation.odf.fmt.Formats;
@@ -7,6 +8,13 @@ import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.xml.Version;
 
 public interface OpenDocument {
+    /**
+     * Get the path to the OpenDocument file.
+     *
+     * @return the path to the OpenDocument file
+     */
+    public Path getPath();
+
     /**
      * Indicates the type of OpenDocument, a zip archive package or a single XML
      * file
@@ -40,14 +48,16 @@ public interface OpenDocument {
     public Collection<OdfDocument> getSubDocuments();
 
     /**
-     * Get the ODF Package for the OpenDocument, this will be null for a single XML file.
+     * Get the ODF Package for the OpenDocument, this will be null for a single XML
+     * file.
      *
      * @return the ODF Package for the OpenDocument
      */
     public OdfPackage getPackage();
 
     /**
-     * Get the format of the OpenDocument, this will be the declared format of the package
+     * Get the format of the OpenDocument, this will be the declared format of the
+     * package
      * or the parsed format of a single document.
      *
      * @return the format of the OpenDocument

--- a/odf-core/src/main/java/org/openpreservation/odf/document/OpenDocumentImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/document/OpenDocumentImpl.java
@@ -1,5 +1,6 @@
 package org.openpreservation.odf.document;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -11,23 +12,30 @@ import org.openpreservation.odf.pkg.OdfPackageDocument;
 import org.openpreservation.odf.xml.Version;
 
 final class OpenDocumentImpl implements OpenDocument {
+    private final Path path;
     private final OdfDocument document;
     private final OdfPackage pkg;
 
-    private OpenDocumentImpl(OdfDocument document, OdfPackage pkg) {
+    private OpenDocumentImpl(final Path path, OdfDocument document, OdfPackage pkg) {
         super();
+        this.path = path;
         this.document = document;
         this.pkg = pkg;
     }
 
-    static final OpenDocument of(OdfDocument document) {
+    static final OpenDocument of(final Path path, OdfDocument document) {
         Objects.requireNonNull(document, "OdfDocument parameter document cannot be null");
-        return new OpenDocumentImpl(document, null);
+        return new OpenDocumentImpl(path, document, null);
     }
 
-    static final OpenDocument of(OdfPackage pkg) {
+    static final OpenDocument of(final Path path, OdfPackage pkg) {
         Objects.requireNonNull(pkg, "OdfPackage pkg document cannot be null");
-        return new OpenDocumentImpl(pkg.getDocument(), pkg);
+        return new OpenDocumentImpl(path, pkg.getDocument(), pkg);
+    }
+
+    @Override
+    public Path getPath() {
+        return this.path;
     }
 
     @Override
@@ -74,7 +82,7 @@ final class OpenDocumentImpl implements OpenDocument {
 
     @Override
     public int hashCode() {
-        return Objects.hash(document, pkg);
+        return Objects.hash(path, document, pkg);
     }
 
     @Override
@@ -84,7 +92,7 @@ final class OpenDocumentImpl implements OpenDocument {
         if (!(obj instanceof OpenDocumentImpl))
             return false;
         OpenDocumentImpl other = (OpenDocumentImpl) obj;
-        return Objects.equals(document, other.document) && Objects.equals(pkg, other.pkg);
+        return Objects.equals(path, other.path) && Objects.equals(document, other.document) && Objects.equals(pkg, other.pkg);
     }
 
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Profile.java
@@ -2,9 +2,8 @@ package org.openpreservation.odf.validation;
 
 import java.util.Set;
 
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Profile {
     public String getId();
@@ -13,11 +12,9 @@ public interface Profile {
 
     public String getDescription();
 
-    public ProfileResult check(final OdfXmlDocument document) throws ParseException;
+    public ProfileResult check(final OpenDocument document) throws ParseException;
 
     public ProfileResult check(final ValidationReport report) throws ParseException;
-
-    public ProfileResult check(final OdfPackage odfPackage) throws ParseException;
 
     public Set<Rule> getRules();
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Rule.java
@@ -2,9 +2,8 @@ package org.openpreservation.odf.validation;
 
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public interface Rule {
     public String getId();
@@ -17,9 +16,7 @@ public interface Rule {
 
     public boolean isPrerequisite();
 
-    public MessageLog check(final OdfXmlDocument document) throws ParseException;
-
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException;
+    public MessageLog check(final OpenDocument document) throws ParseException;
 
     public MessageLog check(final ValidationReport report) throws ParseException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParser.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParser.java
@@ -2,6 +2,7 @@ package org.openpreservation.odf.validation;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Path;
 
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.PackageParser;
@@ -15,6 +16,6 @@ public interface ValidatingParser extends PackageParser {
      * @throws IOException if there's a problem reading package elements from the
      *                     zip file.
      */
-    public ValidationReport validatePackage(final OdfPackage odfPackage)
+    public ValidationReport validatePackage(final Path path, final OdfPackage odfPackage)
             throws ParseException, FileNotFoundException;
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidatingParserImpl.java
@@ -61,7 +61,7 @@ final class ValidatingParserImpl implements ValidatingParser {
     }
 
     @Override
-    public ValidationReport validatePackage(final OdfPackage toValidate) {
+    public ValidationReport validatePackage(final Path path, final OdfPackage toValidate) {
         Objects.requireNonNull(toValidate, String.format(Checks.NOT_NULL, TO_VALIDATE, "OdfPackage"));
         this.results.clear();
         if (!toValidate.isWellFormedZip()) {
@@ -69,7 +69,7 @@ final class ValidatingParserImpl implements ValidatingParser {
             report.add(toValidate.getName(), FACTORY.getError("PKG-1"));
             return report;
         }
-        return validate(toValidate);
+        return validate(path, toValidate);
     }
 
     @Override
@@ -87,8 +87,8 @@ final class ValidatingParserImpl implements ValidatingParser {
         return this.packageParser.parsePackage(toParse, name);
     }
 
-    private ValidationReport validate(final OdfPackage odfPackage) {
-        final ValidationReport report = ValidationReport.of(odfPackage.getName(), Documents.openDocumentOf(odfPackage));
+    private ValidationReport validate(final Path path, final OdfPackage odfPackage) {
+        final ValidationReport report = ValidationReport.of(odfPackage.getName(), Documents.openDocumentOf(path, odfPackage));
         report.add("package", FACTORY.getInfo("DOC-2", odfPackage.getDetectedVersion().version));
         report.add(OdfFormats.MIMETYPE, checkMimeEntry(odfPackage));
         report.add(OdfPackages.PATH_MANIFEST, validateManifest(odfPackage));

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -106,7 +106,7 @@ public class Validator {
             throws ParserConfigurationException, SAXException, ParseException, FileNotFoundException {
         ValidatingParser parser = Validators.getValidatingParser();
         OdfPackage pckg = parser.parsePackage(toValidate);
-        return parser.validatePackage(pckg);
+        return parser.validatePackage(toValidate, pckg);
     }
 
     private ValidationReport validateOpenDocumentXml(final Path toValidate)
@@ -115,7 +115,7 @@ public class Validator {
         ParseResult parseResult = checker.parse(toValidate);
         final ValidationReport report = (parseResult.isWellFormed())
                 ? ValidationReport.of(toValidate.toString(),
-                        Documents.openDocumentOf(Documents.odfDocumentOf(parseResult)))
+                        Documents.openDocumentOf(toValidate, Documents.odfDocumentOf(parseResult)))
                 : ValidationReport.of(toValidate.toString());
         if (parseResult.isWellFormed()) {
             Version version = Version.ODF_13;

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractProfile.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractProfile.java
@@ -5,11 +5,11 @@ import java.util.Set;
 
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 abstract class AbstractProfile implements Profile {
     final String id;
@@ -46,12 +46,12 @@ abstract class AbstractProfile implements Profile {
     }
 
     @Override
-    public ProfileResult check(OdfXmlDocument document) throws ParseException {
+    public ProfileResult check(OpenDocument document) throws ParseException {
         MessageLog log = Messages.messageLogInstance();
         for (Rule rule : this.rules) {
             log.add(rule.check(document).getMessages());
         }
-        Collections.singletonMap(document.getRootName(), log);
+        Collections.singletonMap(document.getDocument().getXmlDocument().getRootName(), log);
         return null;
     }
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/AbstractRule.java
@@ -5,11 +5,10 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.ValidationReport;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 abstract class AbstractRule implements Rule {
     final String id;
@@ -58,19 +57,12 @@ abstract class AbstractRule implements Rule {
         if (report.document == null) {
             return Messages.messageLogInstance();
         }
-        return report.document.isPackage() ? check(report.document.getPackage())
-                : check(report.document.getDocument().getXmlDocument());
+        return check(report.document);
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) throws ParseException {
+    public MessageLog check(final OpenDocument document) throws ParseException {
         Objects.requireNonNull(document, "document must not be null");
-        return Messages.messageLogInstance();
-    }
-
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         return Messages.messageLogInstance();
     }
 

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRule.java
@@ -5,9 +5,8 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser.ParseException;
 
 final class DigitalSignaturesRule extends AbstractRule {
 
@@ -22,11 +21,11 @@ final class DigitalSignaturesRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+    public MessageLog check(final OpenDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        if (odfPackage.hasDsigEntries()) {
-            for (final String path : odfPackage.getMetaInfMap().keySet()) {
+        if (document.isPackage() && document.getPackage().hasDsigEntries()) {
+            for (final String path : document.getPackage().getMetaInfMap().keySet()) {
                 if (OdfPackages.isDsig(path)) {
                     messageLog.add(path, Messages.getMessageInstance(this.id, this.severity, this.getName(),
                             this.getDescription()));

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRule.java
@@ -4,9 +4,8 @@ import java.util.Objects;
 
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 public class EmbeddedObjectsRule extends AbstractRule {
     static final String ODF6_SCHEMATRON = "org/openpreservation/odf/core/odf/validation/rules/odf-6.sch";
@@ -27,15 +26,9 @@ public class EmbeddedObjectsRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) throws ParseException {
+    public MessageLog check(final OpenDocument document) throws ParseException {
         Objects.requireNonNull(document, "document must not be null");
         return this.schematron.check(document);
-    }
-
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
-        return this.schematron.check(odfPackage);
     }
 
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/EncryptionRule.java
@@ -5,10 +5,9 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.FileEntry;
-import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class EncryptionRule extends AbstractRule {
 
@@ -23,18 +22,13 @@ final class EncryptionRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) {
-        return Messages.messageLogInstance();
-    }
-
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+    public MessageLog check(final OpenDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        if (!odfPackage.hasManifest()) {
+        if (!document.isPackage() || !document.getPackage().hasManifest()) {
             return messageLog;
         }
-        for (final FileEntry entry : odfPackage.getManifest().getEntries()) {
+        for (final FileEntry entry : document.getPackage().getManifest().getEntries()) {
             if (entry.isEncrypted()) {
                 messageLog.add(entry.getFullPath(), Messages.getMessageInstance(this.id, this.severity, this.getName(),
                         this.getDescription()));

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRule.java
@@ -5,10 +5,10 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.document.OdfDocument;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class ExtensionMimeTypeRule extends AbstractRule {
 
@@ -26,7 +26,15 @@ final class ExtensionMimeTypeRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) {
+    public MessageLog check(final OpenDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
+        if (document.isPackage()) {
+            return this.check(document.getPackage());
+        }
+        return this.check(document.getDocument());
+    }
+
+    public MessageLog check(final OdfDocument document) {
         Objects.requireNonNull(document, "document must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         messageLog.add(OdfPackages.MIMETYPE, Messages.getMessageInstance(this.id, this.severity, this.getName(),
@@ -34,8 +42,7 @@ final class ExtensionMimeTypeRule extends AbstractRule {
         return messageLog;
     }
 
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
+    public MessageLog check(final OdfPackage odfPackage) {
         Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         if (!odfPackage.hasMimeEntry()

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRule.java
@@ -5,9 +5,8 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser.ParseException;
 
 final class PackageMimeTypeRule extends AbstractRule {
 
@@ -23,10 +22,10 @@ final class PackageMimeTypeRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+    public MessageLog check(final OpenDocument document) {
+        Objects.requireNonNull(document, "document must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        if (!odfPackage.hasMimeEntry()) {
+        if (document.isPackage() && !document.getPackage().hasMimeEntry()) {
             messageLog.add(OdfPackages.MIMETYPE, Messages.getMessageInstance(this.id, this.severity, this.getName(),
                     this.getDescription()));
         }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
@@ -2,9 +2,10 @@ package org.openpreservation.odf.validation.rules;
 
 import java.io.FileNotFoundException;
 import java.util.Collection;
-import java.util.Set;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -12,7 +13,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.openpreservation.messages.Message;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
@@ -35,9 +36,10 @@ final class ProfileImpl extends AbstractProfile {
     }
 
     @Override
-    public ProfileResult check(final OdfPackage odfPackage) throws ParseException {
+    public ProfileResult check(final OpenDocument document) throws ParseException {
+        Objects.requireNonNull(document, "document must not be null");
         try {
-            return check(this.validatingParser.validatePackage(odfPackage));
+            return check(this.validatingParser.validatePackage(document.getPath(), document.getPackage()));
         } catch (FileNotFoundException e) {
             throw new ParseException("File not found exception when processing package.", e);
         }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
@@ -23,11 +23,7 @@ public class Rules {
     }
 
     public static final Rule odf2() {
-        try {
             return ValidPackageRule.getInstance(Severity.ERROR);
-        } catch (ParserConfigurationException | SAXException e) {
-            throw new IllegalStateException(e);
-        }
     }
 
     public static final Rule odf3() {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SchematronRule.java
@@ -1,15 +1,19 @@
 package org.openpreservation.odf.validation.rules;
 
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.Objects;
 
+import javax.xml.transform.Source;
 import javax.xml.transform.stream.StreamSource;
 
 import org.openpreservation.messages.Message;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.FileEntry;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
@@ -36,26 +40,52 @@ final class SchematronRule extends AbstractRule {
     }
 
     @Override
+    public MessageLog check(final OpenDocument document) throws ParseException {
+        Objects.requireNonNull(document, "document must not be null");
+        if (document.isPackage()) {
+            return this.check(document.getPackage());
+        }
+        try (final InputStream is = new FileInputStream(document.getPath().toFile())) {
+            return check(document.getPath().toString(), is);
+        } catch (IOException e) {
+            throw new ParseException("Unexpected Exception caught when executing Schematron checks.", e);
+        }
+    }
+
     public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
         for (final FileEntry entry : odfPackage.getXmlEntries()) {
             if (!OdfPackages.isOdfXml(entry.getFullPath()) || entry.isEncrypted()) {
                 continue;
             }
             try (InputStream is = odfPackage.getEntryStream(entry)) {
-                final SchematronOutputType schResult = this.schematron
-                        .applySchematronValidationToSVRL(new StreamSource(is));
-                for (final AbstractSVRLMessage result : SVRLHelper
-                        .getAllFailedAssertionsAndSuccessfulReports(schResult)) {
-                    messageLog.add(entry.getFullPath(),
-                            Messages.getMessageInstance(this.id, Message.Severity.valueOf(result.getRole()),
-                                    this.getName(),
-                                    result.getText()));
-                }
-            } catch (final Exception e) {
-                throw new ParseException("Unexpected Exception caught when executing Schematron checks.", e);
+                messageLog.add(check(entry.getFullPath(), is).getMessages());
+            } catch (IOException e) {
+                // No need to catch stream close exception
             }
+        }
+        return messageLog;
+    }
+
+    private MessageLog check(final String entryName, final InputStream is) throws ParseException {
+        SchematronOutputType schResult;
+        Source source = new StreamSource(is);
+        try {
+            schResult = this.schematron
+                    .applySchematronValidationToSVRL(source);
+        } catch (IllegalArgumentException e) {
+            // Ignore unparsable schematron
+            return Messages.messageLogInstance();
+        } catch (Exception e) {
+            throw new ParseException("Unexpected Exception caught when executing Schematron checks.", e);
+        }
+        final MessageLog messageLog = Messages.messageLogInstance();
+        for (final AbstractSVRLMessage result : SVRLHelper
+                .getAllFailedAssertionsAndSuccessfulReports(schResult)) {
+            messageLog.add(entryName,
+                    Messages.getMessageInstance(this.id, Message.Severity.valueOf(result.getRole()),
+                            this.getName(),
+                            result.getText()));
         }
         return messageLog;
     }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/SubDocumentRule.java
@@ -5,10 +5,9 @@ import java.util.Objects;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 final class SubDocumentRule extends AbstractRule {
 
@@ -23,15 +22,10 @@ final class SubDocumentRule extends AbstractRule {
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) {
-        throw new UnsupportedOperationException("Unimplemented method 'check'");
-    }
-
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+    public MessageLog check(final OpenDocument document) throws ParseException {
+        Objects.requireNonNull(document, "document must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        if (odfPackage.hasManifest() && odfPackage.getManifest().getDocumentEntries().size() > 1) {
+        if (document.isPackage() && document.getPackage().hasManifest() && document.getPackage().getManifest().getDocumentEntries().size() > 1) {
             messageLog.add(OdfPackages.PATH_MANIFEST,
                     Messages.getMessageInstance(this.id, this.severity, this.getName(),
                             this.getDescription()));

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ValidPackageRule.java
@@ -3,49 +3,38 @@ package org.openpreservation.odf.validation.rules;
 import java.io.FileNotFoundException;
 import java.util.Objects;
 
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.openpreservation.messages.Message;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Messages;
-import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.validation.ValidatingParser;
 import org.openpreservation.odf.validation.ValidationReport;
-import org.openpreservation.odf.validation.Validators;
-import org.openpreservation.odf.xml.OdfXmlDocument;
+import org.openpreservation.odf.validation.Validator;
 import org.openpreservation.odf.xml.Version;
-import org.xml.sax.SAXException;
 
 class ValidPackageRule extends AbstractRule {
+    private static final String PACK_MESS = "File is not an ODF package. ";
     private static final String VER_MESS = "Package version: %s detected. ";
     private static final String INV_MESS = "Package does not comply with specification. ";
 
-    static final ValidPackageRule getInstance(final Severity severity)
-            throws ParserConfigurationException, SAXException {
+    static final ValidPackageRule getInstance(final Severity severity) {
         return new ValidPackageRule("POL_2", "Standard Compliance",
                 "The file MUST comply with the standard \"OASIS Open Document Format for Office Applications (OpenDocument) v1.3\".",
                 severity, false);
     }
 
-    private final ValidatingParser validatingParser = Validators.getValidatingParser();
-
     private ValidPackageRule(final String id, final String name, final String description, final Severity severity,
-            final boolean isPrerequisite) throws ParserConfigurationException, SAXException {
+            final boolean isPrerequisite) {
         super(id, name, description, severity, isPrerequisite);
     }
 
     @Override
-    public MessageLog check(final OdfXmlDocument document) {
-        throw new UnsupportedOperationException("Unimplemented method 'check'");
-    }
-
-    @Override
-    public MessageLog check(final OdfPackage odfPackage) throws ParseException {
-        Objects.requireNonNull(odfPackage, "odfPackage must not be null");
+    public MessageLog check(final OpenDocument document) throws ParseException {
+        Objects.requireNonNull(document, "document must not be null");
         try {
-            ValidationReport report = this.validatingParser.validatePackage(odfPackage);
+            Validator validator = new Validator();
+            ValidationReport report = validator.validate(document.getPath());
             return check(report);
         } catch (FileNotFoundException e) {
             throw new ParseException("File not found exception when processing package.", e);
@@ -56,10 +45,16 @@ class ValidPackageRule extends AbstractRule {
     public MessageLog check(final ValidationReport report) {
         Objects.requireNonNull(report, "report must not be null");
         final MessageLog messageLog = Messages.messageLogInstance();
-        if (!report.isValid() || !report.document.getVersion().equals(Version.ODF_13)) {
-            String message = "";
-            if (report.document != null && !report.document.getPackage().getDetectedVersion().equals(Version.ODF_13)) {
-                message = String.format(VER_MESS, report.document.getPackage().getDetectedVersion().version);
+        if (report.document == null) {
+            messageLog.add(report.name,
+                    Messages.getMessageInstance(this.id, Message.Severity.ERROR,
+                            this.getName(), PACK_MESS + this.getDescription()));
+            return messageLog;
+        }
+        if (!report.isValid() || !report.document.getVersion().equals(Version.ODF_13) || !report.document.isPackage()) {
+            String message = (!report.document.isPackage()) ? PACK_MESS : "";
+            if (report.document != null && !report.document.getVersion().equals(Version.ODF_13)) {
+                message = String.format(VER_MESS, report.document.getVersion());
             }
             if (!report.isValid()) {
                 message += INV_MESS;

--- a/odf-core/src/test/java/org/openpreservation/format/zip/ZipArchiveTest.java
+++ b/odf-core/src/test/java/org/openpreservation/format/zip/ZipArchiveTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,22 +17,23 @@ import org.junit.Test;
 import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ZipArchiveTest {
+    Path path = Paths.get("");
     @Test
     public void testInstantiation() {
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
-                    ZipArchiveImpl.from(null);
+                    ZipArchiveImpl.from(path, null);
                 });
 
-        ZipArchiveImpl archive = ZipArchiveImpl.from(new ArrayList<>());
+        ZipArchiveImpl archive = ZipArchiveImpl.from(path, new ArrayList<>());
         assertNotNull("Instantiated archive should not be null", archive);
         List<ZipEntry> entries = new ArrayList<>();
         entries.add(null);
         assertThrows("IllegalArgumentException expected",
                 IllegalArgumentException.class,
                 () -> {
-                    ZipArchiveImpl.from(entries);
+                    ZipArchiveImpl.from(path, entries);
                 });
     }
 
@@ -42,20 +45,20 @@ public class ZipArchiveTest {
     @Test
     public void testSize() {
         List<ZipEntry> entries = new ArrayList<>();
-        ZipArchiveImpl archive = ZipArchiveImpl.from(new ArrayList<>());
+        ZipArchiveImpl archive = ZipArchiveImpl.from(path, new ArrayList<>());
         assertEquals("Instantiated archive size should be zero", archive.size(), 0);
         entries.add(ZipEntryImpl.of(""));
-        archive = ZipArchiveImpl.from(entries);
+        archive = ZipArchiveImpl.from(path, entries);
         assertEquals("Instantiated archive size should be one", archive.size(), 1);
     }
 
     @Test
     public void testGetZipEntries() {
         List<ZipEntry> entries = new ArrayList<>();
-        ZipArchiveImpl archive = ZipArchiveImpl.from(new ArrayList<>());
+        ZipArchiveImpl archive = ZipArchiveImpl.from(path, new ArrayList<>());
         assertTrue("Retrieved ZipEntry List should be empty", archive.getZipEntries().isEmpty());
         entries.add(ZipEntryImpl.of("test"));
-        archive = ZipArchiveImpl.from(entries);
+        archive = ZipArchiveImpl.from(path, entries);
         assertFalse("Retrieved ZipEntry List should NOT be empty", archive.getZipEntries().isEmpty());
     }
 
@@ -63,7 +66,7 @@ public class ZipArchiveTest {
     public void testGetZipEntryNull() {
         List<ZipEntry> entries = new ArrayList<>();
         entries.add(ZipEntryImpl.of("test"));
-        ZipArchiveImpl archive = ZipArchiveImpl.from(entries);
+        ZipArchiveImpl archive = ZipArchiveImpl.from(path, entries);
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
@@ -74,10 +77,10 @@ public class ZipArchiveTest {
     @Test
     public void testGetZipEntry() {
         List<ZipEntry> entries = new ArrayList<>();
-        ZipArchiveImpl archive = ZipArchiveImpl.from(new ArrayList<>());
+        ZipArchiveImpl archive = ZipArchiveImpl.from(path, new ArrayList<>());
         assertNull("Retrieved test entry should be null", archive.getZipEntry("test"));
         entries.add(ZipEntryImpl.of("test"));
-        archive = ZipArchiveImpl.from(entries);
+        archive = ZipArchiveImpl.from(path, entries);
         assertNotNull("Retrieved test entry should NOT be null", archive.getZipEntry("test"));
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/document/DocumentsTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/document/DocumentsTest.java
@@ -7,8 +7,11 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -35,38 +38,53 @@ public class DocumentsTest {
     @Test
     public void testOpenDocInstantiationOfNullDocument() {
         OdfDocument nullDoc = null;
+        Path path = Paths.get("");
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
-                    Documents.openDocumentOf(nullDoc);
+                    Documents.openDocumentOf(path, nullDoc);
                 });
     }
 
     @Test
     public void testOpenDocInstantiationOfDocument() throws IOException, ParserConfigurationException, SAXException {
         OdfDocument doc = OdfDocumentImpl.from(TestFiles.EMPTY_FODS.openStream());
-        OpenDocument openDoc = Documents.openDocumentOf(doc);
+        OpenDocument openDoc = Documents.openDocumentOf(Paths.get(""), doc);
         assertNotNull("Parsed OpenDocument should not be null.", openDoc);
         assertFalse("Parsed document should be a package", openDoc.isPackage());
         assertEquals("Document should be a spreadsheet.", Formats.ODS, openDoc.getFormat());
     }
 
     @Test
-    public void testOpenDocInstantiationOfNullPackage() {
-        OdfPackage nullPkg = null;
+    public void testOpenDocInstantiationOfNullPath() throws FileNotFoundException, ParseException, URISyntaxException {
+        PackageParser parser = OdfPackages.getPackageParser();
+        OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
+        Path nullPath = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
-                    Documents.openDocumentOf(nullPkg);
+                    Documents.openDocumentOf(nullPath, pkg);
+                });
+    }
+
+    @Test
+    public void testOpenDocInstantiationOfNullPackage() {
+        OdfPackage nullPkg = null;
+        Path path = Paths.get("");
+        assertThrows("NullPointerException expected",
+                NullPointerException.class,
+                () -> {
+                    Documents.openDocumentOf(path, nullPkg);
                 });
     }
 
     @Test
     public void testOpenDocInstantiationOfPackage()
-            throws IOException, ParseException, URISyntaxException {
+            throws ParseException, URISyntaxException, FileNotFoundException {
         PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = Documents.openDocumentOf(pkg);
+        File file = new File(TestFiles.EMPTY_ODS.toURI());
+        OdfPackage pkg = parser.parsePackage(file);
+        OpenDocument openDoc = Documents.openDocumentOf(file.toPath(), pkg);
         assertNotNull("Parsed OpenDocument should not be null.", openDoc);
         assertTrue("Parsed document should be a package", openDoc.isPackage());
         assertEquals("Document should be a spreadsheet.", Formats.ODS, openDoc.getFormat());

--- a/odf-core/src/test/java/org/openpreservation/odf/document/OpenDocumentImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/document/OpenDocumentImplTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Paths;
 
 import javax.xml.parsers.ParserConfigurationException;
 
@@ -34,7 +35,7 @@ public class OpenDocumentImplTest {
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
-                    OpenDocumentImpl.of(nullDoc);
+                    OpenDocumentImpl.of(Paths.get(""), nullDoc);
                 });
     }
 
@@ -44,14 +45,14 @@ public class OpenDocumentImplTest {
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
-                    OpenDocumentImpl.of(nullPkg);
+                    OpenDocumentImpl.of(Paths.get(""), nullPkg);
                 });
     }
 
     @Test
     public void testGetDocumentSingle() throws IOException, ParserConfigurationException, SAXException {
         OdfDocument odfDoc = OdfDocumentImpl.from(TestFiles.EMPTY_FODS.openStream());
-        OpenDocument openDoc = OpenDocumentImpl.of(odfDoc);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), odfDoc);
         assertEquals("Expected instantiating and return document to be equal", odfDoc, openDoc.getDocument());
     }
 
@@ -59,14 +60,14 @@ public class OpenDocumentImplTest {
     public void testGetDocumentPackage() throws IOException, ParseException, URISyntaxException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = OpenDocumentImpl.of(pkg);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), pkg);
         assertEquals("Expected instantiating and return document to be equal", pkg.getDocument(), openDoc.getDocument());
     }
 
     @Test
     public void testGetFileTypeSingle() throws IOException, ParserConfigurationException, SAXException {
         OdfDocument odfDoc = OdfDocumentImpl.from(TestFiles.EMPTY_FODS.openStream());
-        OpenDocument openDoc = OpenDocumentImpl.of(odfDoc);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), odfDoc);
         assertEquals(FileType.SINGLE, openDoc.getFileType());
     }
 
@@ -74,7 +75,7 @@ public class OpenDocumentImplTest {
     public void testGetFileTypePackage() throws IOException, ParseException, URISyntaxException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = OpenDocumentImpl.of(pkg);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), pkg);
         assertEquals(FileType.PACKAGE, openDoc.getFileType());
     }
 
@@ -82,7 +83,7 @@ public class OpenDocumentImplTest {
     public void testGetPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = OpenDocumentImpl.of(pkg);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), pkg);
         assertEquals("Expected instantiating and return package to be equal", pkg, openDoc.getPackage());
     }
 
@@ -90,7 +91,7 @@ public class OpenDocumentImplTest {
     public void testGetSubDocuments() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = OpenDocumentImpl.of(pkg);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), pkg);
         assertEquals("Expected instantiating and return package sub-docs to be equal", pkg.getSubDocument("Configurations2/"), openDoc.getSubDocuments().toArray()[0]);
         assertEquals("Expected one sub-document", 1, openDoc.getSubDocuments().size());
     }
@@ -98,7 +99,7 @@ public class OpenDocumentImplTest {
     @Test
     public void testIsPackageSingle() throws IOException, ParserConfigurationException, SAXException {
         OdfDocument odfDoc = OdfDocumentImpl.from(TestFiles.EMPTY_FODS.openStream());
-        OpenDocument openDoc = OpenDocumentImpl.of(odfDoc);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), odfDoc);
         assertFalse(openDoc.isPackage());
     }
 
@@ -106,7 +107,7 @@ public class OpenDocumentImplTest {
     public void testIsPackagePackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
         OdfPackage pkg = parser.parsePackage(new File(TestFiles.EMPTY_ODS.toURI()));
-        OpenDocument openDoc = OpenDocumentImpl.of(pkg);
+        OpenDocument openDoc = OpenDocumentImpl.of(Paths.get(""), pkg);
         assertTrue(openDoc.isPackage());
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/Utilities.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/Utilities.java
@@ -1,0 +1,25 @@
+package org.openpreservation.odf.validation;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.openpreservation.odf.pkg.OdfPackage;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
+import org.xml.sax.SAXException;
+
+public class Utilities {
+
+    static ValidationReport getValidationReport(final URL resource)
+            throws URISyntaxException, ParseException, ParserConfigurationException, SAXException, IOException {
+        ValidatingParser parser = Validators.getValidatingParser();
+        InputStream is = resource.openStream();
+        OdfPackage pkg = parser.parsePackage(is, resource.toString());
+        return parser.validatePackage(Paths.get(new File(resource.toURI()).getAbsolutePath()), pkg);
+    }
+}

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
@@ -102,29 +102,22 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testValidPackage() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.EMPTY_ODS.openStream(), TestFiles.EMPTY_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testValidPackage() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.EMPTY_ODS);
         assertTrue("Empty ODS IS valid", report.isValid());
     }
 
     @Test
-    public void testInValidZip() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.FAKEMIME_TEXT.openStream(), TestFiles.FAKEMIME_TEXT.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testInValidZip() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.FAKEMIME_TEXT);
         assertFalse("FAKEMIME should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-1")).count() > 0);
     }
 
     @Test
     public void testBadlyFormedPackage()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.BADLY_FORMED_PKG.openStream(),
-                TestFiles.BADLY_FORMED_PKG.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.BADLY_FORMED_PKG);
         assertFalse("BADLY_FORMED_PKG should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-4")).count() > 0);
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-3")).count() > 0);
@@ -132,255 +125,182 @@ public class ValidatingParserTest {
     }
 
     @Test
-    public void testNoManifest() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.NO_MANIFEST_ODS.openStream(),
-                TestFiles.NO_MANIFEST_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoManifest() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.NO_MANIFEST_ODS);
         assertFalse("NO_MANIFEST_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-3")).count() > 0);
     }
 
     @Test
     public void testManifestRootNoMime()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_ROOT_NO_MIME_ODS.openStream(),
-                TestFiles.MANIFEST_ROOT_NO_MIME_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_ROOT_NO_MIME_ODS);
         assertFalse("MANIFEST_ROOT_NO_MIME_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-4")).count() > 0);
     }
 
     @Test
     public void testManifestRootRandMimetype()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_RAND_MIMETYPE_ODS.openStream(),
-                TestFiles.MANIFEST_RAND_MIMETYPE_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_RAND_MIMETYPE_ODS);
         assertFalse("MANIFEST_RAND_MIMETYPE_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
     }
 
     @Test
     public void testManifestRandRootMime()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_RAND_ROOT_MIME_ODS.openStream(),
-                TestFiles.MANIFEST_RAND_ROOT_MIME_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_RAND_ROOT_MIME_ODS);
         assertFalse("MANIFEST_RAND_ROOT_MIME_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
     }
 
     @Test
     public void testManifestRootDiffMime()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_DIFF_MIME_ODS.openStream(),
-                TestFiles.MANIFEST_DIFF_MIME_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_DIFF_MIME_ODS);
         assertFalse("MANIFEST_DIFF_MIME_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
     }
 
     @Test
     public void testManifestEmptyRootMime()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS.openStream(),
-                TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS);
         assertFalse("MANIFEST_EMPTY_ROOT_MIME_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
     }
 
     @Test
-    public void testManifestEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_ENTRY_ODS.openStream(),
-                TestFiles.MANIFEST_ENTRY_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testManifestEntry() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_ENTRY_ODS);
         assertFalse("MANIFEST_ENTRY_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-2")).count() > 0);
     }
 
     @Test
-    public void testMimetypeEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MIMETYPE_ENTRY_ODS.openStream(),
-                TestFiles.MIMETYPE_ENTRY_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMimetypeEntry() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MIMETYPE_ENTRY_ODS);
         assertFalse("MIMETYPE_ENTRY_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-3")).count() > 0);
     }
 
     @Test
-    public void testMetainfEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.METAINF_ENTRY_ODT.openStream(),
-                TestFiles.METAINF_ENTRY_ODT.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMetainfEntry() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.METAINF_ENTRY_ODT);
         assertFalse("METAINF_ENTRY_ODT should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-6")).count() > 0);
     }
 
     @Test
     public void testMissingManifestEntry()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_MISSING_ENTRY_ODS.openStream(),
-                TestFiles.MANIFEST_MISSING_ENTRY_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_MISSING_ENTRY_ODS);
         assertFalse("MANIFEST_MISSING_ENTRY_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-1")).count() > 0);
     }
 
     @Test
-    public void testMissingXmlEntry() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS.openStream(),
-                TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMissingXmlEntry() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS);
         assertFalse("MANIFEST_MISSING_XML_ENTRY_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-1")).count() > 0);
     }
 
     @Test
-    public void testMissingFile() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MISSING_FILE_ODS.openStream(),
-                TestFiles.MISSING_FILE_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMissingFile() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MISSING_FILE_ODS);
         assertFalse("MISSING_FILE_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-4")).count() > 0);
     }
 
     @Test
-    public void testNoMimeWithRoot() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.NO_MIME_ROOT_ODS.openStream(),
-                TestFiles.NO_MIME_ROOT_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoMimeWithRoot() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.NO_MIME_ROOT_ODS);
         assertFalse("NO_MIME_ROOT_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-4")).count() > 0);
     }
 
     @Test
-    public void testNoRootMimeTyoe() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS.openStream(),
-                TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoRootMimeTyoe() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS);
         assertFalse("MANIFEST_NO_ROOT_MIMETYPE_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-5")).count() > 0);
     }
 
     @Test
-    public void testNoMimeNoRoot() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.NO_MIME_NO_ROOT_ODS.openStream(),
-                TestFiles.NO_MIME_NO_ROOT_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoMimeNoRoot() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.NO_MIME_NO_ROOT_ODS);
         assertTrue("NO_MIME_NO_ROOT_ODS should be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-4")).count() > 0);
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-7")).count() > 0);
     }
 
     @Test
-    public void testMimeLast() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MIME_LAST_ODS.openStream(), TestFiles.MIME_LAST_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMimeLast() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MIME_LAST_ODS);
         assertFalse("MIME_LAST_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-1")).count() > 0);
     }
 
     @Test
-    public void testMimeCompressed() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MIME_COMPRESSED_ODS.openStream(),
-                TestFiles.MIME_COMPRESSED_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMimeCompressed() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MIME_COMPRESSED_ODS);
         assertFalse("MIME_COMPRESSED_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-2")).count() > 0);
     }
 
     @Test
     public void testMimeCompressedLast()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MIME_COMPRESSED_LAST_ODS.openStream(),
-                TestFiles.MIME_COMPRESSED_LAST_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MIME_COMPRESSED_LAST_ODS);
         assertFalse("MIME_COMPRESSED_LAST_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-1")).count() > 0);
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-2")).count() > 0);
     }
 
     @Test
-    public void testMimeExtra() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.MIME_EXTRA_ODS.openStream(),
-                TestFiles.MIME_EXTRA_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testMimeExtra() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.MIME_EXTRA_ODS);
         assertFalse("MIME_EXTRA_ODS should NOT be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-3")).count() > 0);
     }
 
     @Test
-    public void testNoThumbnail() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.NO_THUMBNAIL_ODS.openStream(),
-                TestFiles.NO_THUMBNAIL_ODS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoThumbnail() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.NO_THUMBNAIL_ODS);
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-7")).count() > 0);
     }
 
     @Test
-    public void testNoEmbeddedWord() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.EMBEDDED_WORD.openStream(), TestFiles.EMBEDDED_WORD.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testNoEmbeddedWord() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.EMBEDDED_WORD);
         assertTrue("EMBEDDED_WORD IS valid", report.isValid());
     }
 
     @Test
-    public void testPasswordEncrypted() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        OdfPackage pkg = parser.parsePackage(TestFiles.ENCRYPTED_PASSWORDS.openStream(),
-                TestFiles.ENCRYPTED_PASSWORDS.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testPasswordEncrypted() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.ENCRYPTED_PASSWORDS);
         assertTrue("ENCRYPTED_PASSWORDS should be valid", report.isValid());
         assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-10")).count() > 0);
     }
 
     @Test
-    public void testDsigValid() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        InputStream is = TestFiles.DSIG_VALID.openStream();
-        OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_VALID.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testDsigValid() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.DSIG_VALID);
         assertTrue("Package is not valid", report.isValid());
     }
 
     @Test
-    public void testDsigInvalid() throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        InputStream is = TestFiles.DSIG_INVALID.openStream();
-        OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_INVALID.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+    public void testDsigInvalid() throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.DSIG_INVALID);
         assertFalse("Package should be NOT be valid, dsig file has bad version", report.isValid());
     }
 
     @Test
     public void testDsigInvalidBadName()
-            throws ParserConfigurationException, SAXException, IOException, ParseException {
-        ValidatingParser parser = Validators.getValidatingParser();
-        InputStream is = TestFiles.DSIG_BADNAME.openStream();
-        OdfPackage pkg = parser.parsePackage(is, TestFiles.DSIG_BADNAME.toString());
-        ValidationReport report = parser.validatePackage(pkg);
+            throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
+        ValidationReport report = Utilities.getValidationReport(TestFiles.DSIG_BADNAME);
         assertFalse("Package should be NOT be valid, badly named META-INF file.", report.isValid());
         assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("PKG-5")).count());
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
@@ -6,18 +6,22 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.Documents;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;
@@ -35,22 +39,11 @@ public class ContentTest {
     @Test
     public void testCheckNullXmlDoc() {
         Rule rule = Rules.odf7();
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
-        NullPointerException.class,
+                NullPointerException.class,
                 () -> {
                     rule.check(nullDoc);
-                });
-    }
-
-    @Test
-    public void testCheckNullPackage() {
-        Rule rule = Rules.odf7();
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-        NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
                 });
     }
 
@@ -77,22 +70,15 @@ public class ContentTest {
     }
 
     @Test
-    public void testPackageContentFail() throws Exception {
-        final Rule odf7 = Rules.odf7();
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog messages = odf7.check(pkg);
+    public void testPackageContentFail() throws FileNotFoundException, ParseException, URISyntaxException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, Rules.odf7());
         assertNotNull(messages);
         assertEquals(1, messages.getWarnings().size());
-        assertEquals(1, messages.getMessages().values().stream().filter(m -> m.stream().filter(e -> e.getId().equals("POL_7")).count() > 0).count());
     }
 
     @Test
-    public void testPackageContentPass() throws Exception {
-        final Rule odf7 = Rules.odf7();
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.SCHEMATRON_CHECKER_ODS.toURI()).getAbsolutePath()));
-        MessageLog messages = odf7.check(pkg);
+    public void testPackageContentPass() throws FileNotFoundException, ParseException, URISyntaxException {
+        MessageLog messages = Utils.getMessages(TestFiles.SCHEMATRON_CHECKER_ODS, Rules.odf7());
         assertNotNull(messages);
         assertEquals(0, messages.getErrors().size());
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
@@ -6,20 +6,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -38,7 +34,7 @@ public class DigitalSignaturesRuleTest {
 
     @Test
     public void testCheckNullXmlDoc() {
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
@@ -47,54 +43,34 @@ public class DigitalSignaturesRuleTest {
     }
 
     @Test
-    public void testCheckNullPackage() {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
-                });
-    }
-
-    @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Valid Package should not return errors", results.hasErrors());
+    public void testCheckValidPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
+        assertFalse("Valid Package should not return errors", messages.hasErrors());
     }
 
     @Test
     public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Document XML should NOT return errors", results.hasErrors());
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_FODS, rule);
+        assertFalse("Document XML should NOT return errors", messages.hasErrors());
     }
 
     @Test
     public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Badly formed package does not contain digital signatures.", results.hasErrors());
+        MessageLog messages = Utils.getMessages(TestFiles.BADLY_FORMED_PKG, rule);
+        assertFalse("Badly formed package does not contain digital signatures.", messages.hasErrors());
     }
 
     @Test
     public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Invalid extra headers for mimetype is OK.", results.hasErrors());
+        MessageLog messages = Utils.getMessages(TestFiles.MIME_EXTRA_ODS, rule);
+        assertFalse("Invalid extra headers for mimetype is OK.", messages.hasErrors());
     }
 
     @Test
     public void testCheckValidDsigPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.DSIG_VALID.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("File contains valid digital signatures.", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+        MessageLog messages = Utils.getMessages(TestFiles.DSIG_VALID, rule);
+        assertTrue("File contains valid digital signatures.", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_9")).count() > 0).count());
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
@@ -6,23 +6,19 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
 import org.openpreservation.messages.Message.Severity;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;
@@ -41,21 +37,11 @@ public class EmbeddedObjectsRuleTest {
 
     @Test
     public void testCheckNullXmlDoc() {
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
                     rule.check(nullDoc);
-                });
-    }
-
-    @Test
-    public void testCheckNullPackage() {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
                 });
     }
 
@@ -82,20 +68,15 @@ public class EmbeddedObjectsRuleTest {
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Valid Package should not return errors", results.hasErrors());
+    public void testCheckValidPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
+        assertFalse("Valid Package should not return errors", messages.hasErrors());
     }
 
     @Test
     public void testCheckEmbeddedPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser
-                .parsePackage(Paths.get(new File(TestFiles.OLE_EMBEDDED_PACKAGE.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Valid Package should not return errors.", results.hasErrors());
-        assertTrue("Valid Package should have info messages.", results.hasInfos());
+        MessageLog messages = Utils.getMessages(TestFiles.OLE_EMBEDDED_PACKAGE, rule);
+        assertFalse("Valid Package should not return errors.", messages.hasErrors());
+        assertTrue("Valid Package should have info messages.", messages.hasInfos());
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
@@ -13,14 +13,14 @@ import java.nio.file.Paths;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.Documents;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.Formats;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
 import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -39,7 +39,7 @@ public class ExtensionMimeTypeRuleTest {
 
     @Test
     public void testCheckNullXmlDoc() {
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
@@ -48,67 +48,49 @@ public class ExtensionMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNullPackage() {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
-                });
-    }
-
-    @Test
     public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Valid Package should not return errors", results.hasErrors());
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
+        assertFalse("Valid Package should not return errors", messages.hasErrors());
     }
 
     @Test
     public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_FODS, rule);
+        assertTrue("Document XML should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_4")).count() > 0).count());
     }
 
     @Test
     public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Badly formed package should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+        MessageLog messages = Utils.getMessages(TestFiles.BADLY_FORMED_PKG, rule);
+        assertTrue("Badly formed package should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_4")).count() > 0).count());
     }
 
     @Test
     public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Invalid extra headers for mimetype is OK.", results.hasErrors());
+        MessageLog messages = Utils.getMessages(TestFiles.MIME_EXTRA_ODS, rule);
+        assertFalse("Invalid extra headers for mimetype is OK.", messages.hasErrors());
     }
 
     @Test
     public void testCheckNotOdsPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.DSIG_INVALID.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("DSIG file has wrong MIME and extension", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+        MessageLog messages = Utils.getMessages(TestFiles.DSIG_INVALID, rule);
+        assertTrue("DSIG file has wrong MIME and extension", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_4")).count() > 0).count());
     }
 
     @Test
     public void testCheckBadExtPackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_EXT.toURI()).getAbsolutePath()));
-        assertEquals("Package should have spreadsheet MIME value", Formats.ODS.mime, pkg.getMimeType());
-        MessageLog results = rule.check(pkg);
+        OpenDocument doc = Documents.openDocumentOf(
+                Paths.get(new File(TestFiles.ODF4_BAD_EXT.toURI()).getAbsolutePath()),
+                parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_EXT.toURI()).getAbsolutePath())));
+        assertEquals("Package should have spreadsheet MIME value", Formats.ODS.mime, doc.getPackage().getMimeType());
+        MessageLog results = rule.check(doc);
         assertTrue("Bad extension only but should be invalid", results.hasErrors());
         assertEquals(1, results.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_4")).count() > 0).count());
@@ -117,10 +99,12 @@ public class ExtensionMimeTypeRuleTest {
     @Test
     public void testCheckBadMimePackage() throws IOException, URISyntaxException, ParseException {
         PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_MIME.toURI()).getAbsolutePath()));
-        assertEquals("Package should have template MIME value", Formats.OTS.mime, pkg.getMimeType());
-        assertTrue("Package should have spreadsheet extension.", pkg.getName().endsWith(Formats.ODS.extension));
-        MessageLog results = rule.check(pkg);
+        OpenDocument doc = Documents.openDocumentOf(Paths.get(new File(TestFiles.ODF4_BAD_MIME.toURI()).getAbsolutePath()), 
+                parser.parsePackage(Paths.get(new File(TestFiles.ODF4_BAD_MIME.toURI()).getAbsolutePath())));
+        assertEquals("Package should have template MIME value", Formats.OTS.mime, doc.getPackage().getMimeType());
+        assertTrue("Package should have spreadsheet extension.",
+                doc.getPackage().getName().endsWith(Formats.ODS.extension));
+        MessageLog results = rule.check(doc);
         assertTrue("Bad extension only but should be invalid", results.hasErrors());
         assertEquals(1, results.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_4")).count() > 0).count());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
@@ -5,19 +5,14 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;
@@ -35,7 +30,7 @@ public class ExternalDataTest {
     @Test
     public void testCheckNullXmlDoc() {
         Rule rule = Rules.odf5();
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
@@ -43,16 +38,6 @@ public class ExternalDataTest {
                 });
     }
 
-    @Test
-    public void testCheckNullPackage() {
-        Rule rule = Rules.odf5();
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
-                });
-    }
 
     @Test
     public void testSchematronExternalDataFail() throws Exception {
@@ -78,11 +63,7 @@ public class ExternalDataTest {
 
     @Test
     public void testPackageExternalDataFail() throws Exception {
-        final Rule odf5 = Rules.odf5();
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser
-                .parsePackage(Paths.get(new File(TestFiles.SCHEMATRON_CHECKER_ODS.toURI()).getAbsolutePath()));
-        MessageLog messages = odf5.check(pkg);
+        MessageLog messages = Utils.getMessages(TestFiles.SCHEMATRON_CHECKER_ODS, Rules.odf5());
         assertNotNull(messages);
         assertEquals(0, messages.getErrors().size());
         assertEquals(1, messages.getInfos().size());
@@ -92,10 +73,7 @@ public class ExternalDataTest {
 
     @Test
     public void testPackageExternalDataPass() throws Exception {
-        final Rule odf5 = Rules.odf5();
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MACRO_PACKAGE.toURI()).getAbsolutePath()));
-        MessageLog messages = odf5.check(pkg);
+        MessageLog messages = Utils.getMessages(TestFiles.MACRO_PACKAGE, Rules.odf5());
         assertNotNull(messages);
         assertEquals(0, messages.getErrors().size());
     }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
@@ -5,20 +5,15 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.List;
 
 import org.junit.Test;
-import org.openpreservation.messages.MessageLog;
 import org.openpreservation.messages.Message.Severity;
+import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;
@@ -37,21 +32,11 @@ public class MacrosTest {
 
     @Test
     public void testCheckNullXmlDoc() {
-        OdfXmlDocument nullDoc = null;
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
                     rule.check(nullDoc);
-                });
-    }
-
-    @Test
-    public void testCheckNullPackage() {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
                 });
     }
 
@@ -79,9 +64,7 @@ public class MacrosTest {
 
     @Test
     public void testPackageMacroFail() throws Exception {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MACRO_PACKAGE.toURI()).getAbsolutePath()));
-        MessageLog messages = rule.check(pkg);
+        MessageLog messages = Utils.getMessages(TestFiles.MACRO_PACKAGE, rule);
         assertNotNull(messages);
         assertEquals(2, messages.getErrors().size());
         assertEquals(2, messages.getMessages().values().stream()
@@ -90,18 +73,14 @@ public class MacrosTest {
 
     @Test
     public void testPackageNoMacroPass() throws Exception {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog messages = rule.check(pkg);
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
         assertNotNull(messages);
         assertEquals(0, messages.getErrors().size());
     }
 
     @Test
     public void testPackageStarBasicFail() throws Exception {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.STAR_BASIC.toURI()).getAbsolutePath()));
-        MessageLog messages = rule.check(pkg);
+        MessageLog messages = Utils.getMessages(TestFiles.STAR_BASIC, rule);
         assertNotNull(messages);
         assertEquals(1, messages.getErrors().size());
         assertEquals(1, messages.getMessages().values().stream()

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
@@ -6,20 +6,16 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
@@ -37,8 +33,8 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNullXmlDoc() throws ParseException {
-        OdfXmlDocument nullDoc = null;
+    public void testCheckNullXmlDoc() {
+        OpenDocument nullDoc = null;
         assertThrows("NullPointerException expected",
                 NullPointerException.class,
                 () -> {
@@ -47,69 +43,46 @@ public class PackageMimeTypeRuleTest {
     }
 
     @Test
-    public void testCheckNullPackage() {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
-                });
+    public void testCheckValidPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
+        assertFalse("Valid Package should not return errors", messages.hasErrors());
     }
 
     @Test
-    public void testCheckValidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Valid Package should not return errors", results.hasErrors());
-    }
-
-    @Test
-    public void testCheckNotZipPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+    public void testCheckNotZipPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_FODS, rule);
+        assertTrue("Document XML should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_3")).count() > 0).count());
     }
 
     @Test
-    public void testCheckNotWellFormedPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Badly formed package should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+    public void testCheckNotWellFormedPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.BADLY_FORMED_PKG, rule);
+        assertTrue("Badly formed package should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_3")).count() > 0).count());
     }
 
     @Test
-    public void testCheckInvalidPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Invalid extra headers for mimetype is OK.", results.hasErrors());
+    public void testCheckInvalidPackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.MIME_EXTRA_ODS, rule);
+        assertFalse("Invalid extra headers for mimetype is OK.", messages.hasErrors());
     }
 
     @Test
-    public void testCheckNoMimePackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.NO_MIME_ROOT_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("No mimetype with root entry (invalid) return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+    public void testCheckNoMimePackage() throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.NO_MIME_ROOT_ODS, rule);
+        assertTrue("No mimetype with root entry (invalid) return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_3")).count() > 0).count());
     }
 
     @Test
     public void testCheckNoMimeNoRootPackage() throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser
-                .parsePackage(Paths.get(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("No mimetype with no root entry (valid) should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+        MessageLog messages = Utils.getMessages(TestFiles.NO_MIME_NO_ROOT_ODS, rule);
+        assertTrue("No mimetype with no root entry (valid) should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_3")).count() > 0).count());
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
@@ -3,18 +3,14 @@ package org.openpreservation.odf.validation.rules;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ProfileResult;
@@ -22,11 +18,10 @@ import org.xml.sax.SAXException;
 
 public class ProfileImplTest {
     @Test
-    public void testCheck() throws IOException, URISyntaxException, ParseException, ParserConfigurationException, SAXException {
+    public void testCheck() throws URISyntaxException, ParseException, ParserConfigurationException, SAXException , FileNotFoundException {
         Profile profile = Rules.getDnaProfile();
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        ProfileResult result = profile.check(pkg);
+        OpenDocument doc = Utils.getDocument(TestFiles.EMPTY_ODS);
+        ProfileResult result = profile.check(doc);
         assertNotNull(result);
         assertTrue(result.getValidationReport().isValid());
         assertTrue(result.isValid());

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/Utils.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/Utils.java
@@ -1,0 +1,29 @@
+package org.openpreservation.odf.validation.rules;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.Documents;
+import org.openpreservation.odf.document.OpenDocument;
+import org.openpreservation.odf.pkg.OdfPackages;
+import org.openpreservation.odf.pkg.PackageParser;
+import org.openpreservation.odf.pkg.PackageParser.ParseException;
+import org.openpreservation.odf.validation.Rule;
+
+public class Utils {
+    private static final PackageParser parser = OdfPackages.getPackageParser();
+
+    static OpenDocument getDocument(final URL resource) throws URISyntaxException, FileNotFoundException, ParseException {
+        Path path = Paths.get(new File(resource.toURI()).getAbsolutePath());
+        return Documents.openDocumentOf(path, parser.parsePackage(path));
+    }
+
+    static MessageLog getMessages(final URL resource, Rule rule) throws URISyntaxException, FileNotFoundException, ParseException {
+        return rule.check(getDocument(resource));
+    }
+}

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
@@ -6,22 +6,17 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.net.URISyntaxException;
-import java.nio.file.Paths;
 
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.junit.Test;
 import org.openpreservation.messages.MessageLog;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
-import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.pkg.OdfPackages;
-import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.xml.OdfXmlDocument;
 import org.xml.sax.SAXException;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
@@ -31,7 +26,7 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testEqualsContract() {
-        EqualsVerifier.forClass(ValidPackageRule.class).withIgnoredFields("validatingParser").verify();
+        EqualsVerifier.forClass(ValidPackageRule.class).verify();
     }
 
     @Test
@@ -41,63 +36,45 @@ public class ValidPackageRuleTest {
 
     @Test
     public void testCheckNullXmlDoc() throws ParserConfigurationException, SAXException {
-        OdfXmlDocument nullDoc = null;
-        assertThrows("UnsupportedOperationException expected",
-                UnsupportedOperationException.class,
+        OpenDocument nullDoc = null;
+        assertThrows("NullPointerException expected",
+        NullPointerException.class,
                 () -> {
                     rule.check(nullDoc);
                 });
     }
 
     @Test
-    public void testCheckNullPackage() throws ParserConfigurationException, SAXException {
-        OdfPackage nullPkg = null;
-        assertThrows("NullPointerException expected",
-                NullPointerException.class,
-                () -> {
-                    rule.check(nullPkg);
-                });
-    }
-
-    @Test
     public void testCheckValidPackage()
-            throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertFalse("Package should NOT return errors", results.hasErrors());
+            throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_ODS, rule);
+        assertFalse("Package should NOT return errors", messages.hasErrors());
     }
 
     @Test
     public void testCheckNotZipPackage()
-            throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.EMPTY_FODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+            throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.EMPTY_FODS, rule);
+        assertTrue("Document XML should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 
     @Test
     public void testCheckNotWellFormedPackage()
-            throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.BADLY_FORMED_PKG.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+            throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.BADLY_FORMED_PKG, rule);
+        assertTrue("Document XML should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 
     @Test
     public void testCheckInvalidPackage()
-            throws IOException, URISyntaxException, ParseException {
-        PackageParser parser = OdfPackages.getPackageParser();
-        OdfPackage pkg = parser.parsePackage(Paths.get(new File(TestFiles.MIME_EXTRA_ODS.toURI()).getAbsolutePath()));
-        MessageLog results = rule.check(pkg);
-        assertTrue("Document XML should return errors", results.hasErrors());
-        assertEquals(1, results.getMessages().values().stream()
+            throws URISyntaxException, ParseException, FileNotFoundException {
+        MessageLog messages = Utils.getMessages(TestFiles.MIME_EXTRA_ODS, rule);
+        assertTrue("Document XML should return errors", messages.hasErrors());
+        assertEquals(1, messages.getMessages().values().stream()
                 .filter(m -> m.stream().filter(e -> e.getId().equals("POL_2")).count() > 0).count());
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-compress</artifactId>
-        <version>1.23.0</version>
+        <version>1.27.1</version>
       </dependency>
       <!-- https://mvnrepository.com/artifact/junit/junit -->
       <dependency>


### PR DESCRIPTION
Also a start to the upcoming refactoring. The `Profile` and `Rule` classes now check `OpenDocument` objects rather than `OdfPackage` or `OdfXmlDocument` objects. This is a step towards the upcoming refactoring where the `OpenDocument` class will be the main class for handling OpenDocument files.

- `Profile` and `Rule` now check `OpenDocument` objects rather than `OdfPackage` or `OdfXmlDocument` objects;
- sensible flat file implementations now added for all policies (this still means returning an empty message list for some that are package exclusive);
- `OpenDocument` now has a `Path` attribute and instantiation now requires a `Path` object;
- added a `path` attribute to the `ZipArchive` so that tracing a documents source is easier;
- updated version of commons-compress to 1.27.1;
- replaced deprecated `ZipFile` constructors with `ZipFile.Builder` instantiation; and
- refactored some test duplication.