### PR TITLE
FIX: Crash on single file policy check

### DIFF
--- a/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
+++ b/odf-apps/src/main/java/org/openpreservation/odf/apps/CliValidator.java
@@ -81,7 +81,7 @@ class CliValidator implements Callable<Integer> {
     private ProfileResult profileReport(final ValidationReport toProfile, final Path path) {
         try {
             final Profile dnaProfile = Rules.getDnaProfile();
-            return dnaProfile.check(toProfile.document);
+            return dnaProfile.check(toProfile);
         } catch (IllegalArgumentException e) {
             this.logMessage(path, Messages.getMessageInstance("APP-2", Severity.ERROR, e.getMessage()));
         } catch (ParseException | ParserConfigurationException | SAXException e) {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validator.java
@@ -16,6 +16,7 @@ import org.openpreservation.format.xml.XmlValidator;
 import org.openpreservation.messages.MessageFactory;
 import org.openpreservation.messages.Messages;
 import org.openpreservation.odf.document.Documents;
+import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.Formats;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.OdfPackages;
@@ -113,6 +114,17 @@ public class Validator {
             throws ParserConfigurationException, SAXException, IOException {
         final XmlParser checker = new XmlParser();
         ParseResult parseResult = checker.parse(toValidate);
+        return validateParseResult(toValidate, parseResult);
+    }
+
+    public ValidationReport validateOpenDocument(final OpenDocument toValidate)
+            throws IOException {
+        ParseResult parseResult = toValidate.getDocument().getXmlDocument().getParseResult();
+        return validateParseResult(toValidate.getPath(), parseResult);
+    }
+
+    private ValidationReport validateParseResult(final Path toValidate, ParseResult parseResult)
+            throws IOException {
         final ValidationReport report = (parseResult.isWellFormed())
                 ? ValidationReport.of(toValidate.toString(),
                         Documents.openDocumentOf(toValidate, Documents.odfDocumentOf(parseResult)))

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Validators.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Validators.java
@@ -3,7 +3,10 @@ package org.openpreservation.odf.validation;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.openpreservation.format.zip.ZipEntry;
+import org.openpreservation.odf.document.OpenDocument;
 import org.xml.sax.SAXException;
+
+import net.sf.saxon.lib.Validation;
 
 public class Validators {
 
@@ -26,6 +29,14 @@ public class Validators {
      */
     public static boolean isCompressionValid(final ZipEntry entry) {
         return ValidatingParserImpl.isCompressionValid(entry);
+    }
+
+    public static final ValidationReport reportOf(final String name) {
+        return ValidationReport.of(name);
+    }
+
+    public static final ValidationReport reportOf(final String name, final OpenDocument document) {
+        return ValidationReport.of(name, document);
     }
 
     private Validators() {

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/ProfileImpl.java
@@ -1,6 +1,7 @@
 package org.openpreservation.odf.validation.rules;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,7 @@ import org.openpreservation.odf.validation.ProfileResult;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.ValidatingParser;
 import org.openpreservation.odf.validation.ValidationReport;
+import org.openpreservation.odf.validation.Validator;
 import org.openpreservation.odf.validation.Validators;
 import org.xml.sax.SAXException;
 
@@ -39,9 +41,14 @@ final class ProfileImpl extends AbstractProfile {
     public ProfileResult check(final OpenDocument document) throws ParseException {
         Objects.requireNonNull(document, "document must not be null");
         try {
-            return check(this.validatingParser.validatePackage(document.getPath(), document.getPackage()));
+            ValidationReport report = document.isPackage()
+                    ? this.validatingParser.validatePackage(document.getPath(), document.getPackage())
+                    : new Validator().validateOpenDocument(document);
+            return check(report);
         } catch (FileNotFoundException e) {
             throw new ParseException("File not found exception when processing package.", e);
+        } catch (IOException e) {
+            throw new ParseException("IO exception when processing package.", e);
         }
     }
 


### PR DESCRIPTION
- added catch to Profile so that flat files are validate properly;
- added a method to validated from OpenDocument to `org.openpreservation.odf.validation.Validator` as a stop gap before API review;
- threaded OpenDocument convenience methods through `org.openpreservation.odf.validation.Validators`; and
- use `ValidationReport`, not document from CLI profile.