### PR TITLE
FEAT: Replace messages with Checks

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Check.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Check.java
@@ -1,0 +1,31 @@
+package org.openpreservation.odf.validation;
+
+import java.util.List;
+
+import org.openpreservation.odf.validation.messages.Message;
+
+/**
+ * Interface for a check, the application of a validation rule and message to an ODF document.
+ */
+public interface Check {
+    /**
+     * Get the message associated with the check.
+     *
+     * @return the message
+     */
+    public Message getMessage();
+
+    /**
+     * Get the path to the element in the ODF document that the check applies to.
+     *
+     * @return the path
+     */
+    public String getPath();
+
+    /**
+     * Get the parameters associated with the check.
+     *
+     * @return the parameters
+     */
+    public List<Parameter> getParameters();
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/CheckImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/CheckImpl.java
@@ -1,0 +1,33 @@
+package org.openpreservation.odf.validation;
+
+import java.util.List;
+
+import org.openpreservation.odf.validation.messages.Message;
+
+public class CheckImpl implements Check {
+    private final Message message;
+    private final String path;
+    private final List<Parameter> parameters;
+
+    public CheckImpl(final Message message, final String path, final List<Parameter> parameters) {
+        this.message = message;
+        this.path = path;
+        this.parameters = parameters;
+    }
+
+    @Override
+    public Message getMessage() {
+        return message;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/Parameter.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/Parameter.java
@@ -1,0 +1,7 @@
+package org.openpreservation.odf.validation;
+
+public interface Parameter {
+    public String getName();
+
+    public String getValue();
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ParameterImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ParameterImpl.java
@@ -1,0 +1,22 @@
+package org.openpreservation.odf.validation;
+
+public class ParameterImpl implements Parameter {
+    private final String name;
+    private final String value;
+
+    public ParameterImpl(final String name, final String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResult.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResult.java
@@ -31,7 +31,7 @@ public interface ProfileResult {
      * @see MessageLog
      * @return the MessageLog associated with the profile result
      */
-    @JsonProperty("messages")
+    @JsonIgnore
     public MessageLog getMessageLog();
 
     /**
@@ -40,8 +40,8 @@ public interface ProfileResult {
      * @see Message
      * @return the Messages associated with the profile result
      */
-    @JsonIgnore
-    public List<Message> getMessages();
+    @JsonProperty("checks")
+    public List<Check> getChecks();
 
     /**
      * Check if the profile is valid

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResultImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ProfileResultImpl.java
@@ -1,9 +1,7 @@
 package org.openpreservation.odf.validation;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import org.openpreservation.odf.validation.messages.Message;
 import org.openpreservation.odf.validation.messages.MessageLog;
 
 final class ProfileResultImpl implements ProfileResult {
@@ -34,8 +32,8 @@ final class ProfileResultImpl implements ProfileResult {
     }
 
     @Override
-    public List<Message> getMessages() {
-        return this.messageLog.getMessages().values().stream().flatMap(List::stream).collect(Collectors.toList());
+    public List<Check> getChecks() {
+        return this.messageLog.getChecks();
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReport.java
@@ -3,7 +3,6 @@ package org.openpreservation.odf.validation;
 import java.util.List;
 
 import org.openpreservation.odf.pkg.Manifest;
-import org.openpreservation.odf.validation.messages.Message;
 import org.openpreservation.odf.validation.messages.Message.Severity;
 import org.openpreservation.odf.xml.Metadata;
 
@@ -55,12 +54,13 @@ public interface ValidationReport {
      * @return 
      */
     @JsonIgnore
-    public List<Message> getMessages();
+    public List<Check> getChecks();
 
     /**
      * Do any of the contained results contain the specified severity?
      *
      * @return true if any of the validation result messages contain the specified severity.
      */
+    @JsonIgnore
     public boolean hasSeverity(Severity severity);
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReportImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationReportImpl.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.openpreservation.odf.pkg.Manifest;
 import org.openpreservation.odf.pkg.OdfPackage;
-import org.openpreservation.odf.validation.messages.Message;
 import org.openpreservation.odf.validation.messages.Message.Severity;
 import org.openpreservation.odf.xml.Metadata;
 
@@ -103,18 +102,18 @@ public class ValidationReportImpl implements ValidationReport {
     }
 
     @Override
-    public List<Message> getMessages() {
-        List<Message> messages =  (this.validationResult == null) ? new ArrayList<>() : this.validationResult.getMessages();
+    public List<Check> getChecks() {
+        List<Check> messages =  (this.validationResult == null) ? new ArrayList<>() : this.validationResult.getChecks();
         if (this.profileResult != null) {
-            messages.addAll(this.profileResult.getMessages());
+            messages.addAll(this.profileResult.getChecks());
         }
         return messages;
     }
 
     @Override
     public boolean hasSeverity(Severity severity) {
-        for (Message msg : this.getMessages()) {
-            if (msg.getSeverity() == severity) {
+        for (Check check : this.getChecks()) {
+            if (check.getMessage().getSeverity() == severity) {
                 return true;
             }
         }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationResult.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationResult.java
@@ -3,7 +3,6 @@ package org.openpreservation.odf.validation;
 import java.util.List;
 
 import org.openpreservation.odf.fmt.Formats;
-import org.openpreservation.odf.validation.messages.Message;
 import org.openpreservation.odf.validation.messages.MessageLog;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -44,20 +43,15 @@ public interface ValidationResult {
      *
      * @return a list of all of the validation messages for the OpenDocument
      */
-    @JsonIgnore
-    List<Message> getMessages();
+    @JsonProperty("checks")
+    List<Check> getChecks();
+
     /**
-     * Get all of the validation errors for the OpenDocument.
+     * Get the profile message log
      *
-     * @return a list of all of the validation errors for the OpenDocument
+     * @see MessageLog
+     * @return the MessageLog associated with the profile result
      */
     @JsonIgnore
-    List<Message> getErrors();
-    /**
-     * Get the message log instance for the report
-     *
-     * @return the message log instance for the report
-     */
-    @JsonProperty("messages")
-    MessageLog getMessageLog();
+    public MessageLog getMessageLog();
 }

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationResultImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/ValidationResultImpl.java
@@ -3,7 +3,6 @@ package org.openpreservation.odf.validation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.Formats;
@@ -70,18 +69,13 @@ public final class ValidationResultImpl implements ValidationResult {
     }
 
     @Override
-    public List<Message> getErrors() {
-        return documentMessages.getErrors().values().stream().flatMap(List::stream).collect(Collectors.toList());
-    }
-
-    @Override
-    public List<Message> getMessages() {
-        return documentMessages.getMessages().values().stream().flatMap(List::stream).collect(Collectors.toList());
-    }
-
-    @Override
     public MessageLog getMessageLog() {
         return this.documentMessages;
+    }
+
+    @Override
+    public List<Check> getChecks() {
+        return documentMessages.getChecks();
     }
 
     @Override

--- a/odf-core/src/main/java/org/openpreservation/odf/validation/messages/MessageLog.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/messages/MessageLog.java
@@ -4,6 +4,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.openpreservation.odf.validation.Check;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -60,7 +62,7 @@ public interface MessageLog {
      * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of error messages
      */
     @JsonIgnore
-    public Map<String, List<Message>> getErrors();
+    public List<Check> getErrors();
 
     /**
      * Get all warning messages in the log.
@@ -68,7 +70,7 @@ public interface MessageLog {
      * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of warning messages
      */
     @JsonIgnore
-    public Map<String, List<Message>> getWarnings();
+    public List<Check> getWarnings();
 
     /**
      * Get all info messages in the log.
@@ -76,7 +78,14 @@ public interface MessageLog {
      * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of info messages
      */
     @JsonIgnore
-    public Map<String, List<Message>> getInfos();
+    public List<Check> getInfos();
+
+    /**
+     * Get all messages in the log.
+     *
+     * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of all messages
+     */
+    public List<Check> getChecks();
 
     /**
      * Get all messages in the log.
@@ -147,7 +156,7 @@ public interface MessageLog {
      * @param severity the {@link Message.Severity} of the messages to be retrieved
      * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of messages of the specified severity
      */
-    public Map<String, List<Message>> getMessagesBySeverity(final Message.Severity severity);
+    public List<Check> getChecksBySeverity(final Message.Severity severity);
 
     /**
      * Get all messages in the log for a particular ID
@@ -155,7 +164,7 @@ public interface MessageLog {
      * @param id the <code>String</code> ID of the messages to be retrieved
      * @return a <code>Map&lt;String, List&lt;Message&gt;&gt;</code> of messages for the specified ID
      */
-    public Map<String, List<Message>> getMessagesById(final String id);
+    public List<Check> getChecksById(final String id);
 
     /**
      * Get all messages in the log for a particular path
@@ -163,5 +172,5 @@ public interface MessageLog {
      * @param path the <code>String</code> path of the messages to be retrieved
      * @return a <code>List&lt;Message&gt;</code> of messages for the specified path
      */
-    public List<Message> getMessagesForPath(final String path);
+    public List<Check> getChecksForPath(final String path);
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/Utilities.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/Utilities.java
@@ -9,9 +9,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.validation.ValidatingParser;
-import org.openpreservation.odf.validation.ValidationResult;
-import org.openpreservation.odf.validation.Validators;
 import org.xml.sax.SAXException;
 
 public class Utilities {

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatingParserTest.java
@@ -20,9 +20,6 @@ import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.OdfPackage;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.validation.ValidatingParser;
-import org.openpreservation.odf.validation.ValidationResult;
-import org.openpreservation.odf.validation.Validators;
 import org.xml.sax.SAXException;
 
 public class ValidatingParserTest {
@@ -116,7 +113,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.FAKEMIME_TEXT);
         assertFalse("FAKEMIME should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-1")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-1"));
     }
 
     @Test
@@ -124,9 +121,9 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.BADLY_FORMED_PKG);
         assertFalse("BADLY_FORMED_PKG should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-4")).count() > 0);
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-3")).count() > 0);
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-7")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-3"));
+        assertTrue(hasMessage(report, "PKG-4"));
+        assertTrue(hasMessage(report, "PKG-7"));
     }
 
     @Test
@@ -134,7 +131,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.NO_MANIFEST_ODS);
         assertFalse("NO_MANIFEST_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-3")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-3"));
     }
 
     @Test
@@ -142,7 +139,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_ROOT_NO_MIME_ODS);
         assertFalse("MANIFEST_ROOT_NO_MIME_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-4")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-4"));
     }
 
     @Test
@@ -150,7 +147,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_RAND_MIMETYPE_ODS);
         assertFalse("MANIFEST_RAND_MIMETYPE_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-5"));
     }
 
     @Test
@@ -158,7 +155,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_RAND_ROOT_MIME_ODS);
         assertFalse("MANIFEST_RAND_ROOT_MIME_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-5"));
     }
 
     @Test
@@ -166,7 +163,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_DIFF_MIME_ODS);
         assertFalse("MANIFEST_DIFF_MIME_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-5"));
     }
 
     @Test
@@ -174,7 +171,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_EMPTY_ROOT_MIME_ODS);
         assertFalse("MANIFEST_EMPTY_ROOT_MIME_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-5")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-5"));
     }
 
     @Test
@@ -182,7 +179,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_ENTRY_ODS);
         assertFalse("MANIFEST_ENTRY_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-2")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-2"));
     }
 
     @Test
@@ -190,7 +187,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MIMETYPE_ENTRY_ODS);
         assertFalse("MIMETYPE_ENTRY_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-3")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-3"));
     }
 
     @Test
@@ -198,7 +195,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.METAINF_ENTRY_ODT);
         assertFalse("METAINF_ENTRY_ODT should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-6")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-6"));
     }
 
     @Test
@@ -206,7 +203,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_MISSING_ENTRY_ODS);
         assertFalse("MANIFEST_MISSING_ENTRY_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-1")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-1"));
     }
 
     @Test
@@ -214,7 +211,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_MISSING_XML_ENTRY_ODS);
         assertFalse("MANIFEST_MISSING_XML_ENTRY_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-1")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-1"));
     }
 
     @Test
@@ -222,7 +219,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MISSING_FILE_ODS);
         assertFalse("MISSING_FILE_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-4")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-4"));
     }
 
     @Test
@@ -230,7 +227,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.NO_MIME_ROOT_ODS);
         assertFalse("NO_MIME_ROOT_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-4")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-4"));
     }
 
     @Test
@@ -238,7 +235,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MANIFEST_NO_ROOT_MIMETYPE_ODS);
         assertFalse("MANIFEST_NO_ROOT_MIMETYPE_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-5")).count() > 0);
+        assertTrue(hasMessage(report, "MAN-5"));
     }
 
     @Test
@@ -246,8 +243,8 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.NO_MIME_NO_ROOT_ODS);
         assertTrue("NO_MIME_NO_ROOT_ODS should be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-4")).count() > 0);
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MAN-7")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-4"));
+        assertTrue(hasMessage(report, "MAN-7"));
     }
 
     @Test
@@ -255,7 +252,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MIME_LAST_ODS);
         assertFalse("MIME_LAST_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-1")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-1"));
     }
 
     @Test
@@ -263,7 +260,7 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MIME_COMPRESSED_ODS);
         assertFalse("MIME_COMPRESSED_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-2")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-2"));
     }
 
     @Test
@@ -271,8 +268,8 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MIME_COMPRESSED_LAST_ODS);
         assertFalse("MIME_COMPRESSED_LAST_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-1")).count() > 0);
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-2")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-1"));
+        assertTrue(hasMessage(report, "MIM-2"));
     }
 
     @Test
@@ -280,14 +277,14 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.MIME_EXTRA_ODS);
         assertFalse("MIME_EXTRA_ODS should NOT be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("MIM-3")).count() > 0);
+        assertTrue(hasMessage(report, "MIM-3"));
     }
 
     @Test
     public void testNoThumbnail()
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.NO_THUMBNAIL_ODS);
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-7")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-7"));
     }
 
     @Test
@@ -302,7 +299,11 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.ENCRYPTED_PASSWORDS);
         assertTrue("ENCRYPTED_PASSWORDS should be valid", report.isValid());
-        assertTrue(report.getMessages().stream().filter(m -> m.getId().equals("PKG-10")).count() > 0);
+        assertTrue(hasMessage(report, "PKG-10"));
+    }
+
+    private boolean hasMessage(ValidationResult report, String id) {
+        return report.getChecks().stream().filter(c -> c.getMessage().getId().equals(id)).count() > 0;
     }
 
     @Test
@@ -324,6 +325,6 @@ public class ValidatingParserTest {
             throws ParserConfigurationException, SAXException, IOException, ParseException, URISyntaxException {
         ValidationResult report = Utilities.getValidationReport(TestFiles.DSIG_BADNAME);
         assertFalse("Package should be NOT be valid, badly named META-INF file.", report.isValid());
-        assertEquals(1, report.getMessages().stream().filter(m -> m.getId().equals("PKG-5")).count());
+        assertEquals(1, report.getChecks().stream().filter(m -> m.getMessage().getId().equals("PKG-5")).count());
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidationReportTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidationReportTest.java
@@ -9,9 +9,6 @@ import java.net.URISyntaxException;
 import org.junit.Test;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.validation.ValidationReport;
-import org.openpreservation.odf.validation.ValidationResultImpl;
-import org.openpreservation.odf.validation.Validator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorTest.java
@@ -18,8 +18,6 @@ import org.junit.Test;
 import org.openpreservation.odf.fmt.Formats;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
-import org.openpreservation.odf.validation.ValidationReport;
-import org.openpreservation.odf.validation.Validator;
 import org.xml.sax.SAXException;
 
 public class ValidatorTest {
@@ -70,7 +68,7 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.EMPTY.toURI()).toPath());
         assertFalse("Package should NOT be valid, spreadsheets only.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-1"));
     }
 
     @Test
@@ -92,7 +90,7 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath());
         assertFalse("Document should NOT be valid.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
+        assertEquals(1, getMessageCountById(report, "XML-4"));
     }
 
     @Test
@@ -100,8 +98,8 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validate(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath());
         assertFalse("Document should NOT be valid.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-1"));
+        assertEquals(1, getMessageCountById(report, "XML-3"));
     }
 
     @Test
@@ -109,7 +107,7 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSingleFormat(new File(TestFiles.DSIG_INVALID.toURI()).toPath(), Formats.ODS);
         assertFalse("Package should NOT be valid, spreadsheets only.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-7"));
     }
 
     @Test
@@ -117,7 +115,7 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSingleFormat(new File(TestFiles.EMPTY.toURI()).toPath(), Formats.ODS);
         assertFalse("Package should NOT be valid, spreadsheets only.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-6")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-6"));
     }
 
     @Test
@@ -126,7 +124,7 @@ public class ValidatorTest {
         ValidationReport report = validator
                 .validateSingleFormat(new File(TestFiles.NO_MIME_NO_ROOT_ODS.toURI()).toPath(), Formats.ODS);
         assertFalse("Package should NOT be valid, spreadsheets only.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-7")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-7"));
     }
 
     @Test
@@ -141,7 +139,7 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSingleFormat(new File(TestFiles.FLAT_NOT_VALID.toURI()).toPath(), Formats.ODS);
         assertFalse("Document should NOT be valid.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("XML-4")).count());
+        assertEquals(1, getMessageCountById(report, "XML-4"));
     }
 
     @Test
@@ -149,8 +147,8 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSingleFormat(new File(TestFiles.FLAT_NOT_WF.toURI()).toPath(), Formats.ODS);
         assertFalse("Document should NOT be valid.", report.getValidationResult().isValid());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-1")).count());
-        assertEquals(1, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
+        assertEquals(1, getMessageCountById(report, "DOC-1"));
+        assertEquals(1, getMessageCountById(report, "XML-3"));
     }
 
     @Test
@@ -158,7 +156,11 @@ public class ValidatorTest {
         Validator validator = new Validator();
         ValidationReport report = validator.validateSingleFormat(new File(TestFiles.EXTENDED_SPREADSHEET.toURI()).toPath(), Formats.ODS);
         assertFalse("Document should NOT be valid.", report.getValidationResult().isValid());
-        assertEquals(2, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("DOC-8")).count());
-        assertEquals(0, report.getValidationResult().getMessages().stream().filter(m -> m.getId().equals("XML-3")).count());
+        assertEquals(2, getMessageCountById(report, "DOC-8"));
+        assertEquals(0, getMessageCountById(report, "XML-3"));
+    }
+
+    private int getMessageCountById(ValidationReport report, String id) {
+        return report.getValidationResult().getChecks().stream().filter(c -> c.getMessage().getId().equals(id)).mapToInt(m -> 1).sum();
     }
 }

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorsTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/ValidatorsTest.java
@@ -9,8 +9,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.junit.Test;
 import org.openpreservation.format.zip.ZipEntry;
 import org.openpreservation.format.zip.Zips;
-import org.openpreservation.odf.validation.ValidatingParser;
-import org.openpreservation.odf.validation.Validators;
 import org.xml.sax.SAXException;
 
 public class ValidatorsTest {

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/AbstractRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/AbstractRuleTest.java
@@ -1,7 +1,6 @@
 package org.openpreservation.odf.validation.rules;
 
 import org.junit.Test;
-import org.openpreservation.odf.validation.rules.AbstractRule;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ContentTest.java
@@ -16,8 +16,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.Rules;
-import org.openpreservation.odf.validation.rules.SchematronRule;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/DigitalSignaturesRuleTest.java
@@ -16,8 +16,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.DigitalSignaturesRule;
-import org.openpreservation.odf.validation.rules.Rules;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EmbeddedObjectsRuleTest.java
@@ -17,10 +17,8 @@ import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.validation.messages.MessageLog;
 import org.openpreservation.odf.validation.messages.Message.Severity;
-import org.openpreservation.odf.validation.rules.EmbeddedObjectsRule;
-import org.openpreservation.odf.validation.rules.Rules;
+import org.openpreservation.odf.validation.messages.MessageLog;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EncryptionRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/EncryptionRuleTest.java
@@ -15,8 +15,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.EncryptionRule;
-import org.openpreservation.odf.validation.rules.Rules;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExtensionMimeTypeRuleTest.java
@@ -21,8 +21,6 @@ import org.openpreservation.odf.pkg.PackageParser;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.ExtensionMimeTypeRule;
-import org.openpreservation.odf.validation.rules.Rules;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ExternalDataTest.java
@@ -13,8 +13,6 @@ import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.Rules;
-import org.openpreservation.odf.validation.rules.SchematronRule;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/MacrosTest.java
@@ -12,10 +12,8 @@ import org.junit.Test;
 import org.openpreservation.odf.document.OpenDocument;
 import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.validation.Rule;
-import org.openpreservation.odf.validation.messages.MessageLog;
 import org.openpreservation.odf.validation.messages.Message.Severity;
-import org.openpreservation.odf.validation.rules.MacroRule;
-import org.openpreservation.odf.validation.rules.Rules;
+import org.openpreservation.odf.validation.messages.MessageLog;
 
 import com.helger.commons.io.resource.URLResource;
 import com.helger.schematron.pure.SchematronResourcePure;

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/PackageMimeTypeRuleTest.java
@@ -16,8 +16,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.PackageMimeTypeRule;
-import org.openpreservation.odf.validation.rules.Rules;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ProfileImplTest.java
@@ -14,7 +14,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Profile;
 import org.openpreservation.odf.validation.ValidationReport;
-import org.openpreservation.odf.validation.rules.Rules;
 import org.xml.sax.SAXException;
 
 public class ProfileImplTest {

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/SubDocumentRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/SubDocumentRuleTest.java
@@ -16,8 +16,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.Rules;
-import org.openpreservation.odf.validation.rules.SubDocumentRule;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 

--- a/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
+++ b/odf-core/src/test/java/org/openpreservation/odf/validation/rules/ValidPackageRuleTest.java
@@ -17,8 +17,6 @@ import org.openpreservation.odf.fmt.TestFiles;
 import org.openpreservation.odf.pkg.PackageParser.ParseException;
 import org.openpreservation.odf.validation.Rule;
 import org.openpreservation.odf.validation.messages.MessageLog;
-import org.openpreservation.odf.validation.rules.Rules;
-import org.openpreservation.odf.validation.rules.ValidPackageRule;
 import org.xml.sax.SAXException;
 
 import nl.jqno.equalsverifier.EqualsVerifier;


### PR DESCRIPTION
- using a new class `Check` to represent the application of a `Rule`;
  - combines `Message`, String `Path` and a list of a `name`/`value` `Parameter` type;
- no longer using `Mesage`s and `MessageLog`s for reporting; and
- fixed/refactored tests.