### PR TITLE
MAINT: Build release artifacts

### DIFF
--- a/.github/workflows/build-native-images.yml
+++ b/.github/workflows/build-native-images.yml
@@ -1,0 +1,81 @@
+name: "Native Images"
+# author: Carl Wilson <carl_AT_openpreservation.org>
+
+on:
+  workflow_call:
+    inputs:
+      release_version:
+        description: "Release version"
+        required: true
+        type: string
+      release_tag:
+        description: "Release tag"
+        required: true
+        type: string
+      pom_version:
+        description: "POM version"
+        required: true
+        type: string
+jobs:
+  build:
+    name: "Build and Publish Native Images"
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: 'ubuntu-latest'
+            label: 'linux'
+            executable: 'odf-apps/target/odf-apps'
+          - os: 'macos-latest'
+            label: 'mac'
+            executable: 'odf-apps/target/odf-apps'
+          - os: 'windows-latest'
+            label: 'windows.exe'
+            executable: 'odf-apps/target/odf-apps.exe'
+    runs-on: ${{matrix.os}}
+    steps:
+    - name: 'Checkout'
+      uses: actions/checkout@v4
+
+    - name: 'Setup GraalVM Environment'
+      uses: graalvm/setup-graalvm@v1
+      with:
+        distribution: 'graalvm'
+        java-version: '17'
+        components: 'native-image'
+
+    - name: 'Get JAR Artifact'
+      uses: actions/download-artifact@v4
+      id: get_jar_artifact
+      with:
+        name: 'odf-validator-${{ inputs.release_version }}-all.jar'
+
+    - name: 'Build Native Image'
+      run: |
+        mvn -Pnative package
+        # native-image --no-fallback \
+        # -H:ResourceConfigurationFiles=native-image/config/resource-config.json \
+        # -H:ReflectionConfigurationFiles=native-image/config/reflect-config.json \
+        # -H:JNIConfigurationFiles=native-image/config/jni-config.json \
+        # -H:Class=org.openpreservation.odf.apps.CliValidator \
+        # -jar odf-apps-${{ inputs.pom_version }}-jar-with-dependencies.jar \
+        # -H:Name=odf-validator-${{ inputs.release_version }}-all
+
+    - name: 'Publish Native Image'
+      if: success()
+      uses: actions/upload-artifact@v4
+      with:
+        name: 'odf-validator-${{ inputs.release_version }}-${{ matrix.label }}'
+        path: '${{ matrix.executable }}'
+
+    - name: "Upload release binaries"
+      if: success()
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: "${{ matrix.executable }}"
+        asset_name: "odf-validator-${{ inputs.release_version }}-${{matrix.label}}"
+        tag: "${{ inputs.release_tag }}"
+        overwrite: true
+        draft: false
+        prerelease: false

--- a/.github/workflows/build-release-jar.yml
+++ b/.github/workflows/build-release-jar.yml
@@ -1,0 +1,66 @@
+name: "Publish Release Artifacts"
+
+on:
+    release:
+        types: [published]
+    workflow_dispatch:
+
+jobs:
+  release_details:
+    uses: carlwilson/odf-validator/.github/workflows/release-details.yml@main
+
+  build:
+    name: "Checkout, build and publish JAR"
+    runs-on: ubuntu-latest
+    needs: release_details
+    outputs:
+      release_version: ${{ needs.release_details.outputs.release_version }}
+      release_tag: ${{ needs.release_details.outputs.release_tag }}
+      pom_version: ${{ steps.pom-version.outputs.version }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "JDK setup"
+        uses: actions/setup-java@v4
+        with:
+          java-version: 11
+          distribution: 'temurin'
+          cache: maven
+
+      - name: "Run pre-commit tests"
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files --verbose
+
+      - name: "Get Maven POM version"
+        id: pom-version
+        run: echo "version=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_OUTPUT
+        
+  
+      - name: "Package using Maven"
+        run: mvn --batch-mode package -DjacocoAgg
+  
+      - name: "Publish JAR"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "odf-validator-${{ needs.release_details.outputs.release_version }}-all.jar"
+          path: "odf-apps/target/odf-apps-*-jar-with-dependencies.jar"
+
+      - name: "Upload release binaries"
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "odf-apps/target/odf-apps-${{ steps.pom-version.outputs.version }}-jar-with-dependencies.jar"
+          asset_name: "odf-validator-${{ needs.release_details.outputs.release_version }}-all.jar"
+          tag: "${{ needs.release_details.outputs.release_tag }}"
+          overwrite: true
+          draft: false
+          prerelease: false
+
+  publish_non_windows:
+    needs: [build]
+    uses: carlwilson/odf-validator/.github/workflows/build-non-windows-image.yml@main
+    with:
+      release_version: ${{ needs.build.outputs.release_version }}
+      release_tag: ${{ needs.build.outputs.release_tag }}
+      pom_version: ${{ needs.build.outputs.pom_version }}

--- a/.github/workflows/release-details.yml
+++ b/.github/workflows/release-details.yml
@@ -1,0 +1,80 @@
+name: Get release details
+
+on:
+  workflow_call:
+    outputs:
+      release_date:
+        description: "Release date only with timestamp removed"
+        value: ${{ jobs.release_details.outputs.release_details }}
+      release_version:
+        description: "Last release version with 'v' removed"
+        value: ${{ jobs.release_details.outputs.release_version }}
+      release_timestamp:
+        description: "Release date with full timestamp information"
+        value: ${{ jobs.release_details.outputs.release_timestamp }}
+      release_tag:
+        description: "Last release tag"
+        value: ${{ jobs.release_details.outputs.release_tag }}
+
+jobs:
+  release_details:
+    runs-on: ubuntu-latest
+    outputs:
+        release_details: ${{ steps.cut_release_date.outputs.substring }}
+        release_version: ${{ steps.cut_release_version.outputs.substring }}
+        release_timestamp: ${{ steps.release_timestamp.outputs.TIMESTAMP }}
+        release_tag: ${{ steps.release_tag.outputs.TAG }}
+
+    steps:
+      - if: github.event.release != null
+        # If this a release event then set the release vars from the event
+        name: set release vars from release event
+        run: |
+          echo "TIMESTAMP=${{ github.event.release.published_at }}" >> $GITHUB_ENV
+          echo "TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
+
+      - if: github.event.release == null
+        # If this is not a release event then get the last release details
+        name: Get previous release
+        id: previousrelease
+        uses: InsonusK/get-latest-release@v1.0.1
+        with:
+          myToken: ${{ github.token }}
+          exclude_types: draft|prerelease
+          view_top: 1
+
+      - if: github.event.release == null
+        # Use the last release details to set the release vars
+        # This is used for the case when this workflow is called from another workflow
+        # and not from a release event
+        name: set release vars from previous release
+        run: |
+          echo "TIMESTAMP=${{ steps.previousrelease.outputs.created_at }}" >> $GITHUB_ENV
+          echo "TAG=${{ steps.previousrelease.outputs.tag_name }}" >> $GITHUB_ENV
+
+      # Shortens the release date to just the date
+      - name: "Shorten release date"
+        uses: bhowell2/github-substring-action@1.0.2
+        id: cut_release_date
+        with:
+          value: ${{ env.TIMESTAMP }}
+          length_from_start: 10
+  
+      # Remove the 'v' from the release version
+      - name: "Remove 'v' from release version"
+        uses: bhowell2/github-substring-action@1.0.2
+        id: cut_release_version
+        with:
+          value: ${{ env.TAG }}
+          index_of_str: "v"
+
+      - name: "Output the release timestamp"
+        id: release_timestamp
+        run: |
+            echo "TIMESTAMP=$TIMESTAMP" >> $GITHUB_OUTPUT
+  
+      - name: "Output the release Tag"
+        id: release_tag
+        run: |
+            echo "TAG=$TAG" >> $GITHUB_OUTPUT
+


### PR DESCRIPTION
Builds a release JAR and native images for Windows, Linux and Mac and makes them available for download on the latest release page. Can be run manually and will use the last release details, otherwise will run on release publication.