### PR TITLE
FIX: Restore no-arg getDnaProfile() overload for backward compatibility

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/validation/rules/Rules.java
@@ -68,6 +68,10 @@ public class Rules {
         return SubDocumentRule.getInstance(Severity.WARNING);
     }
 
+    public static final Profile getDnaProfile() throws ParserConfigurationException, SAXException {
+        return getDnaProfile(false);
+    }
+
     public static final Profile getDnaProfile(final boolean isExtended) throws ParserConfigurationException, SAXException {
         return ProfileImpl.of("DNA", "DNA ODF Spreadsheets Preservation Specification",
                 "Extended validation for OpenDocument spreadsheets.", isExtended ? EXTENDED_DNA_RULES : DNA_RULES, isExtended);


### PR DESCRIPTION
The zero-argument form of Rules.getDnaProfile() was removed when the isExtended parameter was introduced in 0.20. Adds it back as an overload delegating to getDnaProfile(false), preserving the previous default behaviour for existing callers.