### PR TITLE
FIX: Skip manifest entries absent from ZIP in getXmlEntries()

### DIFF
--- a/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
+++ b/odf-core/src/main/java/org/openpreservation/odf/pkg/OdfPackageImpl.java
@@ -223,7 +223,9 @@ final class OdfPackageImpl implements OdfPackage {
         Set<FileEntry> entries = new HashSet<>();
         if (this.manifest != null) {
             for (FileEntry entry : this.manifest.getEntriesByMediaType("text/xml")) {
-                entries.add(entry);
+                if (this.archive != null && this.archive.getZipEntry(entry.getFullPath()) != null) {
+                    entries.add(entry);
+                }
             }
         }
         return entries;


### PR DESCRIPTION
- Profile rules (SchematronRule, MacroRule) iterate over getXmlEntries() and attempt to stream each entry. If a file is listed in the manifest but missing from the ZIP
  - a condition already correctly reported as   MAN-4
  - the underlying ZipFileProcessor threw an unchecked   NoSuchElementException, surfacing as a fatal SYS-4 crash.
- Fix filters getXmlEntries() to only return entries that exist in both   the manifest and the ZIP archive, so profile rules never attempt to   read phantom entries.
- Resolves #282.