### PR TITLE
FIX: Add missing Jing resource bundle to native image config

### DIFF
--- a/native-image/config/resource-config.json
+++ b/native-image/config/resource-config.json
@@ -29,5 +29,8 @@
   }, {
     "name":"org.openpreservation.odf.messages.Messages",
     "locales":[""]
+  }, {
+    "name":"com.thaiopensource.datatype.xsd.resources.Messages",
+    "locales":[""]
   }]
 }

--- a/native-image/config/resource-config.json
+++ b/native-image/config/resource-config.json
@@ -22,6 +22,8 @@
     "pattern":"\\Qorg/openpreservation/odf/schema/odf/1.3/schema.rng\\E"
   }, {
     "pattern":"\\Qorg/xmlresolver/catalog.xml\\E"
+  }, {
+    "pattern":"\\Qorg/openpreservation/odf/apps/build.properties\\E"
   }]},
   "bundles":[{
     "name":"org.openpreservation.odf.apps.messages.Messages",


### PR DESCRIPTION
- com.thaiopensource.datatype.xsd.resources.Messages was not included in the GraalVM native image resource configuration, causing a MissingResourceException crash in the bundled executables.
- Resolves #281.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>