### PR TITLE
FIX: Missing schema for v1.4 in Graal packages

### DIFF
--- a/native-image/config/reflect-config.json
+++ b/native-image/config/reflect-config.json
@@ -254,7 +254,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"getFilename","parameterTypes":[] }, {"name":"getFormat","parameterTypes":[] }, {"name":"getValidationResults","parameterTypes":[] }, {"name":"getVersionString","parameterTypes":[] }, {"name":"isEncrypted","parameterTypes":[] }]
+  "methods":[{"name":"getFilename","parameterTypes":[] }, {"name":"getFormat","parameterTypes":[] }, {"name":"getValidationResults","parameterTypes":[] }, {"name":"getVersionString","parameterTypes":[] }, {"name":"isEncrypted","parameterTypes":[] }, {"name":"isValid","parameterTypes":[] }]
 },
 {
   "name":"org.openpreservation.odf.validation.ValidationResult",
@@ -281,7 +281,7 @@
   "allDeclaredFields":true,
   "queryAllDeclaredMethods":true,
   "queryAllDeclaredConstructors":true,
-  "methods":[{"name":"getId","parameterTypes":[] }, {"name":"getMessage","parameterTypes":[] }, {"name":"getParameters","parameterTypes":[] }, {"name":"getSeverity","parameterTypes":[] }, {"name":"getSubMessage","parameterTypes":[] }, {"name":"getTimestamp","parameterTypes":[] }]
+  "methods":[{"name":"getId","parameterTypes":[] }, {"name":"getMessage","parameterTypes":[] }, {"name":"getParameters","parameterTypes":[] }, {"name":"getSeverity","parameterTypes":[] }, {"name":"getSubMessage","parameterTypes":[] }, {"name":"getTimestamp","parameterTypes":[] }, {"name":"getTitle","parameterTypes":[] }, {"name":"getText","parameterTypes":[] }]
 },
 {
   "name":"org.openpreservation.odf.validation.messages.Parameter",

--- a/native-image/config/resource-config.json
+++ b/native-image/config/resource-config.json
@@ -9,17 +9,15 @@
   }, {
     "pattern":"\\QMETA-INF/services/org.slf4j.spi.SLF4JServiceProvider\\E"
   }, {
-    "pattern":"\\Qorg/openpreservation/odf/core/odf/validation/rules/odf-5.sch\\E"
+    "pattern":"^org/openpreservation/odf/core/odf/validation/rules/.*/*.sch$"
   }, {
-    "pattern":"\\Qorg/openpreservation/odf/core/odf/validation/rules/odf-6.sch\\E"
+    "pattern":"^org/openpreservation/odf/schema/.*/*.dtd$"
   }, {
-    "pattern":"\\Qorg/openpreservation/odf/core/odf/validation/rules/odf-7.sch\\E"
+    "pattern":"^org/openpreservation/odf/schema/.*/*.owl$"
   }, {
-    "pattern":"\\Qorg/openpreservation/odf/core/odf/validation/rules/odf-8.sch\\E"
+    "pattern":"^org/openpreservation/odf/schema/.*/*.rng$"
   }, {
-    "pattern":"\\Qorg/openpreservation/odf/schema/odf/1.3/manifest-schema.rng\\E"
-  }, {
-    "pattern":"\\Qorg/openpreservation/odf/schema/odf/1.3/schema.rng\\E"
+    "pattern":"^org/openpreservation/odf/schema/.*/*.xsd$"
   }, {
     "pattern":"\\Qorg/xmlresolver/catalog.xml\\E"
   }, {
@@ -30,6 +28,9 @@
     "locales":[""]
   }, {
     "name":"org.openpreservation.odf.messages.Messages",
+    "locales":[""]
+  }, {
+    "name":"com.thaiopensource.relaxng.pattern.resources.Messages",
     "locales":[""]
   }, {
     "name":"com.thaiopensource.datatype.xsd.resources.Messages",


### PR DESCRIPTION
Read up a little more and replaced these with wildcards where possible, should be more resilient to new schema and schematron going forward.